### PR TITLE
[FEAT/#40] 토큰 저장 및 공통 헤더 구현

### DIFF
--- a/app/src/main/java/com/smashing/app/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/smashing/app/core/network/AuthInterceptor.kt
@@ -20,7 +20,7 @@ class AuthInterceptor @Inject constructor(
         val newRequest = request.newBuilder()
             .apply {
                 if (!accessToken.isNullOrBlank()) {
-                    addHeader(AUTHORIZATION, "$BEARER_TOKEN $accessToken")
+                    addHeader(AUTHORIZATION, "$BEARER_SUFFIX $accessToken")
                 }
             }
             .build()
@@ -30,7 +30,7 @@ class AuthInterceptor @Inject constructor(
 
     companion object {
         private const val AUTHORIZATION = "Authorization"
-        private const val BEARER_TOKEN = "Bearer"
+        private const val BEARER_SUFFIX = "Bearer"
     }
 
 }

--- a/app/src/main/java/com/smashing/app/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/smashing/app/core/network/AuthInterceptor.kt
@@ -13,13 +13,13 @@ class AuthInterceptor @Inject constructor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
 
-        val accessToken = runBlocking {
+        val accessToken =
             tokenDataSource.getAccessToken()
         }
 
         val newRequest = request.newBuilder()
             .apply {
-                if (accessToken.isNullOrBlank()) {
+                if (!accessToken.isNullOrBlank()) {
                     addHeader(AUTHORIZATION, "$BEARER_TOKEN $accessToken")
                 }
             }

--- a/app/src/main/java/com/smashing/app/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/smashing/app/core/network/AuthInterceptor.kt
@@ -1,5 +1,6 @@
 package com.smashing.app.core.network
 
+import androidx.datastore.preferences.core.stringPreferencesKey
 import com.smashing.app.data.local.datasource.api.LocalTokenDataSource
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
@@ -20,12 +21,17 @@ class AuthInterceptor @Inject constructor(
         val newRequest = request.newBuilder()
             .apply {
                 if (accessToken.isNullOrBlank()) {
-                    addHeader("Authorization", "Bearer $accessToken")
+                    addHeader(AUTHORIZATION, "$BEARER_TOKEN $accessToken")
                 }
             }
             .build()
 
         return chain.proceed(newRequest)
+    }
+
+    companion object {
+        private const val AUTHORIZATION = "Authorization"
+        private const val BEARER_TOKEN = "Bearer"
     }
 
 }

--- a/app/src/main/java/com/smashing/app/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/smashing/app/core/network/AuthInterceptor.kt
@@ -1,6 +1,5 @@
 package com.smashing.app.core.network
 
-import androidx.datastore.preferences.core.stringPreferencesKey
 import com.smashing.app.data.local.datasource.api.LocalTokenDataSource
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor

--- a/app/src/main/java/com/smashing/app/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/smashing/app/core/network/AuthInterceptor.kt
@@ -13,7 +13,7 @@ class AuthInterceptor @Inject constructor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
 
-        val accessToken =
+        val accessToken = runBlocking {
             tokenDataSource.getAccessToken()
         }
 

--- a/app/src/main/java/com/smashing/app/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/smashing/app/core/network/AuthInterceptor.kt
@@ -1,0 +1,31 @@
+package com.smashing.app.core.network
+
+import com.smashing.app.data.local.datasource.api.LocalTokenDataSource
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+class AuthInterceptor @Inject constructor(
+    private val tokenDataSource: LocalTokenDataSource,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+
+        val accessToken = runBlocking {
+            tokenDataSource.getAccessToken()
+        }
+
+        val newRequest = request.newBuilder()
+            .apply {
+                if (accessToken.isNullOrBlank()) {
+                    addHeader("Authorization", "Bearer $accessToken")
+                }
+            }
+            .build()
+
+        return chain.proceed(newRequest)
+    }
+
+}

--- a/app/src/main/java/com/smashing/app/core/network/di/NetworkModule.kt
+++ b/app/src/main/java/com/smashing/app/core/network/di/NetworkModule.kt
@@ -123,7 +123,7 @@ object NetworkModule {
     @Singleton
     @Kakao
     fun provideKakaoRetrofit(
-        client: OkHttpClient,
+        @NoAuth client: OkHttpClient,
         factory: Converter.Factory,
     ): Retrofit = Retrofit.Builder()
         .baseUrl(KAKAO_BASE_URL)

--- a/app/src/main/java/com/smashing/app/core/network/di/NetworkModule.kt
+++ b/app/src/main/java/com/smashing/app/core/network/di/NetworkModule.kt
@@ -4,9 +4,13 @@ import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFact
 import com.smashing.app.BuildConfig
 import com.smashing.app.BuildConfig.BASE_URL
 import com.smashing.app.BuildConfig.KAKAO_BASE_URL
+import com.smashing.app.core.network.AuthInterceptor
 import com.smashing.app.core.network.isJsonArray
 import com.smashing.app.core.network.isJsonObject
+import com.smashing.app.core.network.qualifier.Auth
 import com.smashing.app.core.network.qualifier.Kakao
+import com.smashing.app.core.network.qualifier.NoAuth
+import com.smashing.app.data.local.datasource.api.LocalTokenDataSource
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -67,7 +71,26 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(
+    @Auth
+    fun provideAuthInterceptor(
+        tokenDataSource: LocalTokenDataSource,
+    ): AuthInterceptor = AuthInterceptor(tokenDataSource)
+
+    @Provides
+    @Singleton
+    @Auth
+    fun provideAuthOkHttpClient(
+        loggingInterceptor: Interceptor,
+        @Auth headerInterceptor: AuthInterceptor,
+    ): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(loggingInterceptor)
+        .addInterceptor(headerInterceptor)
+        .build()
+
+    @Provides
+    @Singleton
+    @NoAuth
+    fun provideNoAuthOkHttpClient(
         loggingInterceptor: Interceptor,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
@@ -76,7 +99,19 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideRetrofit(
-        client: OkHttpClient,
+        @Auth client: OkHttpClient,
+        factory: Converter.Factory,
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(client)
+        .addConverterFactory(factory)
+        .build()
+
+    @Provides
+    @Singleton
+    @NoAuth
+    fun provideNoAuthRetrofit(
+        @NoAuth client: OkHttpClient,
         factory: Converter.Factory,
     ): Retrofit = Retrofit.Builder()
         .baseUrl(BASE_URL)

--- a/app/src/main/java/com/smashing/app/core/network/qualifier/NetworkQualifier.kt
+++ b/app/src/main/java/com/smashing/app/core/network/qualifier/NetworkQualifier.kt
@@ -9,3 +9,7 @@ annotation class Kakao
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class NoAuth
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class Auth

--- a/app/src/main/java/com/smashing/app/core/network/qualifier/NetworkQualifier.kt
+++ b/app/src/main/java/com/smashing/app/core/network/qualifier/NetworkQualifier.kt
@@ -5,3 +5,7 @@ import javax.inject.Qualifier
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class Kakao
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class NoAuth

--- a/app/src/main/java/com/smashing/app/data/di/auth/AuthServiceModule.kt
+++ b/app/src/main/java/com/smashing/app/data/di/auth/AuthServiceModule.kt
@@ -22,6 +22,7 @@ object AuthServiceModule {
 
     @Provides
     @Singleton
+    @NoAuth
     fun provideNoAuthService(
         @NoAuth retrofit: Retrofit
     ): AuthService = retrofit.create()

--- a/app/src/main/java/com/smashing/app/data/di/auth/AuthServiceModule.kt
+++ b/app/src/main/java/com/smashing/app/data/di/auth/AuthServiceModule.kt
@@ -1,5 +1,7 @@
 package com.smashing.app.data.di.auth
 
+import com.smashing.app.core.network.qualifier.Auth
+import com.smashing.app.core.network.qualifier.NoAuth
 import com.smashing.app.data.remote.service.AuthService
 import dagger.Module
 import dagger.Provides
@@ -14,5 +16,13 @@ import javax.inject.Singleton
 object AuthServiceModule {
     @Provides
     @Singleton
-    fun provideAuthService(retrofit: Retrofit): AuthService = retrofit.create()
+    fun provideAuthService(
+        @Auth retrofit: Retrofit
+    ): AuthService = retrofit.create()
+
+    @Provides
+    @Singleton
+    fun provideNoAuthService(
+        @NoAuth retrofit: Retrofit
+    ): AuthService = retrofit.create()
 }

--- a/app/src/main/java/com/smashing/app/data/di/auth/AuthServiceModule.kt
+++ b/app/src/main/java/com/smashing/app/data/di/auth/AuthServiceModule.kt
@@ -14,15 +14,9 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object AuthServiceModule {
-    @Provides
-    @Singleton
-    fun provideAuthService(
-        @Auth retrofit: Retrofit
-    ): AuthService = retrofit.create()
 
     @Provides
     @Singleton
-    @NoAuth
     fun provideNoAuthService(
         @NoAuth retrofit: Retrofit
     ): AuthService = retrofit.create()

--- a/app/src/main/java/com/smashing/app/data/local/datasource/api/LocalTokenDatasource.kt
+++ b/app/src/main/java/com/smashing/app/data/local/datasource/api/LocalTokenDatasource.kt
@@ -3,7 +3,6 @@ package com.smashing.app.data.local.datasource.api
 interface LocalTokenDataSource {
     suspend fun getAccessToken(): String?
     suspend fun getRefreshToken(): String?
-    suspend fun setAccessToken(accessToken: String)
-    suspend fun setRefreshToken(refreshToken: String)
+    suspend fun setTokens(accessToken: String, refreshToken: String)
     suspend fun clearTokens()
 }

--- a/app/src/main/java/com/smashing/app/data/local/datasource/impl/LocalTokenDatasourceImpl.kt
+++ b/app/src/main/java/com/smashing/app/data/local/datasource/impl/LocalTokenDatasourceImpl.kt
@@ -24,14 +24,9 @@ class LocalTokenDataSourceImpl @Inject constructor(
             prefs[REFRESH_TOKEN]
         }.firstOrNull()
 
-    override suspend fun setAccessToken(accessToken: String) {
+    override suspend fun setTokens(accessToken: String, refreshToken: String) {
         dataStore.edit { prefs ->
             prefs[ACCESS_TOKEN] = accessToken
-        }
-    }
-
-    override suspend fun setRefreshToken(refreshToken: String) {
-        dataStore.edit { prefs ->
             prefs[REFRESH_TOKEN] = refreshToken
         }
     }

--- a/app/src/main/java/com/smashing/app/data/mapper/KakaoLoginMapper.kt
+++ b/app/src/main/java/com/smashing/app/data/mapper/KakaoLoginMapper.kt
@@ -4,6 +4,6 @@ import com.smashing.app.data.model.auth.KakaoLoginToken
 import com.smashing.app.data.remote.dto.PostKakaoLoginResponse
 
 fun PostKakaoLoginResponse.toKakaoLoginToken() = KakaoLoginToken(
-    accessToken = this.accessToken,
-    refreshToken = this.refreshToken,
+    accessToken = this.accessToken ?: throw IllegalArgumentException("accessToken is null"),
+    refreshToken = this.refreshToken ?: throw IllegalArgumentException("refreshToken is null"),
 )

--- a/app/src/main/java/com/smashing/app/data/model/auth/KakaoLoginToken.kt
+++ b/app/src/main/java/com/smashing/app/data/model/auth/KakaoLoginToken.kt
@@ -1,6 +1,6 @@
 package com.smashing.app.data.model.auth
 
 data class KakaoLoginToken(
-    val accessToken: String?,
-    val refreshToken: String?,
+    val accessToken: String,
+    val refreshToken: String,
 )

--- a/app/src/main/java/com/smashing/app/data/remote/dto/BaseResponse.kt
+++ b/app/src/main/java/com/smashing/app/data/remote/dto/BaseResponse.kt
@@ -3,6 +3,8 @@ package com.smashing.app.data.remote.dto
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+private const val HTTP_OK = 200
+
 @Serializable
 data class BaseResponse<T>(
     @SerialName("status")
@@ -14,3 +16,8 @@ data class BaseResponse<T>(
     @SerialName("timestamp")
     val timestamp: String,
 )
+
+fun <T> BaseResponse<T>.requireData(): T {
+    if (statusCode != HTTP_OK) throw IllegalStateException("API request failed.")
+    return data ?: throw IllegalStateException("Successful response but data was null.")
+}

--- a/app/src/main/java/com/smashing/app/data/remote/service/AuthService.kt
+++ b/app/src/main/java/com/smashing/app/data/remote/service/AuthService.kt
@@ -8,7 +8,6 @@ import retrofit2.http.POST
 interface AuthService {
     @POST("/api/v1/auth/login/kakao")
     suspend fun postKakaoLogin(
-        @Header("Authorization")
         authorization: String,
     ): BaseResponse<PostKakaoLoginResponse>
 }

--- a/app/src/main/java/com/smashing/app/data/repository/impl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/smashing/app/data/repository/impl/AuthRepositoryImpl.kt
@@ -2,16 +2,19 @@ package com.smashing.app.data.repository.impl
 
 import android.content.Context
 import com.smashing.app.core.util.suspendRunCatching
+import com.smashing.app.data.local.datasource.api.LocalTokenDataSource
 import com.smashing.app.data.mapper.toKakaoLoginToken
 import com.smashing.app.data.model.auth.KakaoLoginToken
 import com.smashing.app.data.remote.datasource.api.AuthRemoteDataSource
 import com.smashing.app.data.remote.datasource.api.KakaoAuthDataSource
+import com.smashing.app.data.remote.dto.requireData
 import com.smashing.app.data.repository.api.AuthRepository
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
     private val authRemoteDataSource: AuthRemoteDataSource,
     private val kakaoAuthDataSource: KakaoAuthDataSource,
+    private val tokenDataStore: LocalTokenDataSource,
 ) : AuthRepository {
 
     override suspend fun loginKakao(context: Context): Result<String> =
@@ -19,8 +22,17 @@ class AuthRepositoryImpl @Inject constructor(
 
     override suspend fun postKakaoLogin(authorization: String): Result<KakaoLoginToken> =
         suspendRunCatching {
-            val response = authRemoteDataSource.postKakaoLogin(authorization)
-            response.data?.toKakaoLoginToken()
-                ?: throw IllegalArgumentException("response data is null")
+            val response = authRemoteDataSource.postKakaoLogin(authorization).requireData()
+
+            val token = response.toKakaoLoginToken()
+
+            tokenDataStore.setAccessToken(
+                accessToken = token.accessToken,
+            )
+            tokenDataStore.setRefreshToken(
+                refreshToken = token.refreshToken,
+            )
+
+            token
         }
 }

--- a/app/src/main/java/com/smashing/app/data/repository/impl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/smashing/app/data/repository/impl/AuthRepositoryImpl.kt
@@ -26,10 +26,8 @@ class AuthRepositoryImpl @Inject constructor(
 
             val token = response.toKakaoLoginToken()
 
-            tokenDataStore.setAccessToken(
+            tokenDataStore.setTokens(
                 accessToken = token.accessToken,
-            )
-            tokenDataStore.setRefreshToken(
                 refreshToken = token.refreshToken,
             )
 


### PR DESCRIPTION
## Related issue 🛠
- closed #40

## Work Description ✏️
- datastore에 토큰 저장 로직을 구현합니다
- 공통 헤더를 추가합니다

## Screenshot 📸
<img src="" width="360"/>


## To Reviewers 📢
합숙도 앱잼도 모두 화이팅입니다😊😊


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증 토큰 자동 주입 및 관리 메커니즘 추가
  * 인증된 API 요청과 비인증 요청에 대한 별도의 클라이언트 분리

* **버그 수정**
  * API 응답 데이터 유효성 검증 강화
  * 인증 토큰의 필수값 조건 적용으로 null 값 방지

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->