### PR TITLE
[UI/#61] top bar 구현

### DIFF
--- a/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingDefaultTopBar.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingDefaultTopBar.kt
@@ -29,10 +29,7 @@ fun SmashingDefaultTopBar(
 ) {
     Box(
         modifier = modifier
-            .fillMaxWidth()
-            .background(
-                color = Color.Transparent,
-            ),
+            .fillMaxWidth(),
     ) {
         if(topBarType == TopBarType.BACK && onClick != null){
             Icon(

--- a/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingDefaultTopBar.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingDefaultTopBar.kt
@@ -61,7 +61,7 @@ fun SmashingDefaultTopBar(
                     .align(Alignment.CenterEnd)
                     .padding(end = 16.dp)
                     .noRippleClickable(
-                        onClick = onClick
+                        onClick = onClick,
                     ),
             )
         }

--- a/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingDefaultTopBar.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingDefaultTopBar.kt
@@ -1,0 +1,104 @@
+package com.smashing.app.core.designsystem.component.topbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.smashing.app.R.drawable.ic_arrow_left
+import com.smashing.app.R.drawable.ic_close_lg
+import com.smashing.app.core.designsystem.style.TopBarType
+import com.smashing.app.core.designsystem.theme.SmashingTheme
+import com.smashing.app.core.extension.noRippleClickable
+
+@Composable
+fun SmashingDefaultTopBar(
+    title: String,
+    topBarType: TopBarType,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = Color.Transparent,
+            ),
+    ) {
+        if(topBarType == TopBarType.BACK && onClick != null){
+            Icon(
+                imageVector = ImageVector.vectorResource(ic_arrow_left),
+                contentDescription = null,
+                tint = SmashingTheme.colors.iconPrimary,
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(start = 16.dp)
+                    .noRippleClickable(
+                        onClick = onClick
+                    ),
+            )
+        }
+
+        Text(
+            text = title,
+            style = SmashingTheme.typography.md.semibold16,
+            color = SmashingTheme.colors.txtPrimary,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .padding(vertical = 21.dp),
+        )
+
+        if(topBarType == TopBarType.CLOSE && onClick != null){
+            Icon(
+                imageVector = ImageVector.vectorResource(ic_close_lg),
+                contentDescription = null,
+                tint = SmashingTheme.colors.iconPrimary,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = 16.dp)
+                    .noRippleClickable(
+                        onClick = onClick
+                    ),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+private fun SmashingDefaultTopBarPreview_Default() {
+    SmashingDefaultTopBar(
+        title = "제목",
+        topBarType = TopBarType.DEFAULT,
+        onClick = null,
+    )
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+private fun SmashingDefaultTopBarPreview_Back() {
+    SmashingDefaultTopBar(
+        title = "뒤로가기",
+        topBarType = TopBarType.BACK,
+        onClick = {},
+    )
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+private fun SmashingDefaultTopBarPreview_Close() {
+    SmashingDefaultTopBar(
+        title = "닫기",
+        topBarType = TopBarType.CLOSE,
+        onClick = {},
+    )
+}

--- a/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingDefaultTopBar.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingDefaultTopBar.kt
@@ -43,7 +43,7 @@ fun SmashingDefaultTopBar(
                     .align(Alignment.CenterStart)
                     .padding(start = 16.dp)
                     .noRippleClickable(
-                        onClick = onClick
+                        onClick = onClick,
                     ),
             )
         }

--- a/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingDefaultTopBar.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingDefaultTopBar.kt
@@ -1,6 +1,5 @@
 package com.smashing.app.core.designsystem.component.topbar
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -9,7 +8,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview

--- a/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingSearchTobBar.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingSearchTobBar.kt
@@ -1,0 +1,74 @@
+package com.smashing.app.core.designsystem.component.topbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.smashing.app.R.drawable.ic_arrow_left
+import com.smashing.app.core.designsystem.component.textfield.SearchTextField
+import com.smashing.app.core.designsystem.theme.SmashingAndroidTheme
+import com.smashing.app.core.designsystem.theme.SmashingTheme
+import com.smashing.app.core.extension.noRippleClickable
+
+@Composable
+fun SmashingSearchTobBar(
+    searchState: TextFieldState,
+    placeholder: String,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .background(
+                color = Color.Transparent,
+            )
+            .padding(
+                vertical = 10.dp,
+                horizontal = 16.dp,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(ic_arrow_left),
+            contentDescription = null,
+            tint = SmashingTheme.colors.iconPrimary,
+            modifier = Modifier
+                .noRippleClickable(
+                    onClick = onBackClick
+                ),
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        SearchTextField(
+            state = searchState,
+            placeholder = placeholder,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+private fun SmashingSearchTobBarPreview() {
+    SmashingAndroidTheme {
+        SmashingSearchTobBar(
+            searchState = rememberTextFieldState(),
+            placeholder = "닉네임을 입력해주세요",
+            onBackClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingSearchTobBar.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingSearchTobBar.kt
@@ -32,6 +32,7 @@ fun SmashingSearchTobBar(
 ) {
     Row(
         modifier = modifier
+            .fillMaxWidth()
             .background(
                 color = Color.Transparent,
             )

--- a/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingSearchTobBar.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingSearchTobBar.kt
@@ -1,6 +1,7 @@
 package com.smashing.app.core.designsystem.component.topbar
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,7 +50,7 @@ fun SmashingSearchTobBar(
             tint = SmashingTheme.colors.iconPrimary,
             modifier = Modifier
                 .noRippleClickable(
-                    onClick = onBackClick
+                    onClick = onBackClick,
                 ),
         )
 
@@ -57,7 +59,7 @@ fun SmashingSearchTobBar(
         SearchTextField(
             state = searchState,
             placeholder = placeholder,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         )
     }
 }
@@ -66,10 +68,23 @@ fun SmashingSearchTobBar(
 @Composable
 private fun SmashingSearchTobBarPreview() {
     SmashingAndroidTheme {
-        SmashingSearchTobBar(
-            searchState = rememberTextFieldState(),
-            placeholder = "닉네임을 입력해주세요",
-            onBackClick = {},
-        )
+        val searchState = rememberTextFieldState()
+
+        Column {
+            SmashingSearchTobBar(
+                searchState = searchState,
+                placeholder = "닉네임을 입력해주세요",
+                onBackClick = {},
+            )
+
+            // 입력된 텍스트 표시 (프리뷰 확인용)
+            if (searchState.text.isNotEmpty()) {
+                Text(
+                    text = "입력된 검색어: ${searchState.text}",
+                    color = SmashingTheme.colors.txtPrimary,
+                    modifier = Modifier.padding(16.dp),
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingSearchTopBar.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingSearchTopBar.kt
@@ -35,9 +35,6 @@ fun SmashingSearchTopBar(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .background(
-                color = Color.Transparent,
-            )
             .padding(
                 vertical = 10.dp,
                 horizontal = 16.dp,

--- a/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingSearchTopBar.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingSearchTopBar.kt
@@ -26,7 +26,7 @@ import com.smashing.app.core.designsystem.theme.SmashingTheme
 import com.smashing.app.core.extension.noRippleClickable
 
 @Composable
-fun SmashingSearchTobBar(
+fun SmashingSearchTopBar(
     searchState: TextFieldState,
     placeholder: String,
     onBackClick: () -> Unit,
@@ -70,8 +70,13 @@ private fun SmashingSearchTobBarPreview() {
     SmashingAndroidTheme {
         val searchState = rememberTextFieldState()
 
-        Column {
-            SmashingSearchTobBar(
+        Column(
+            modifier = Modifier
+                .background(
+                    color = SmashingTheme.colors.bgDimmed
+                ),
+        ) {
+            SmashingSearchTopBar(
                 searchState = searchState,
                 placeholder = "닉네임을 입력해주세요",
                 onBackClick = {},

--- a/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingSearchTopBar.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/component/topbar/SmashingSearchTopBar.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview

--- a/app/src/main/java/com/smashing/app/core/designsystem/style/TopBarType.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/style/TopBarType.kt
@@ -1,0 +1,7 @@
+package com.smashing.app.core.designsystem.style
+
+enum class TopBarType {
+    DEFAULT,
+    BACK,
+    CLOSE,
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #61 

## Work Description ✏️
- 기본 탑바 구현
- 검색 탑바 구현

## Screenshot 📸
<img src="" width="360"/>
<img width="312" height="265" alt="image" src="https://github.com/user-attachments/assets/a626d321-4cfe-484b-92bc-fe928ddae5e0" />

https://github.com/user-attachments/assets/6567c1f2-1c17-4584-8d48-2dde2dfaef17



## Uncompleted Tasks 😅

## To Reviewers 📢
- 검색 텍스트 필드 확인 못 했었는데, 검색 전에 placeHolder 부분 수정이 필요해보여요.
- 머지하고 생각이 나서 추가해요. KDoc은 랭킹 관련 스크린 만들고 함께 작성해둘게여.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 뒤로 가기 및 닫기 버튼 옵션이 있는 기본 상단 바 컴포넌트 추가
* 검색 필드가 통합된 검색 상단 바 컴포넌트 추가
* 앱 전체에서 일관된 상단 네비게이션 인터페이스 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->