### PR TITLE
[FEAT/#91] 회원가입 주소 api 연동

### DIFF
--- a/app/src/main/java/com/smashing/app/data/remote/dto/auth/PostSignUpRequest.kt
+++ b/app/src/main/java/com/smashing/app/data/remote/dto/auth/PostSignUpRequest.kt
@@ -15,8 +15,8 @@ data class PostSignUpRequest(
     val openChatUrl: String,
     @SerialName("sportCode")
     val sportCode: String,
-    @SerialName("tier")
-    val tier: String,
+    @SerialName("experienceRange")
+    val experienceRange: String,
     @SerialName("region")
     val region: String,
 )

--- a/app/src/main/java/com/smashing/app/data/type/SkillType.kt
+++ b/app/src/main/java/com/smashing/app/data/type/SkillType.kt
@@ -6,22 +6,22 @@ enum class SkillType(
 ) {
     THREE(
         skillText = "3개월 미만",
-        skillCode = "IRON"
+        skillCode = "LT_3_MONTHS"
     ),
     THREETOSIX(
         skillText = "3개월 이상 ~ 6개월 미만",
-        skillCode = "BRONZE_3"
+        skillCode = "LT_6_MONTHS"
     ),
     SIXTOYEAR(
         skillText = "6개월 이상 ~ 1년 미만",
-        skillCode = "BRONZE_2"
+        skillCode = "LT_1_YEAR"
     ),
     YEARTOYEARSIX(
         skillText = "1년 이상 ~ 1년 6개월 미만",
-        skillCode = "BRONZE_1"
+        skillCode = "LT_1_6_YEARS"
     ),
     YEARSIX(
         skillText = "1년 6개월 이상",
-        skillCode = "SILVER_3"
+        skillCode = "GTE_2_YEARS"
     );
 }

--- a/app/src/main/java/com/smashing/app/presentation/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/navigation/HomeNavigation.kt
@@ -45,7 +45,7 @@ fun NavGraphBuilder.homeGraph(
             val savedStateHandle = backStackEntry.savedStateHandle
 
             RegionChangeRoute(
-                modifier = Modifier.padding(innerPadding),
+                modifier = Modifier,
                 navigateToRegion = navController::navigateToRegion,
                 navigateUp = navController::navigateUp,
                 regionResult = savedStateHandle.getRegionResult(),

--- a/app/src/main/java/com/smashing/app/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/main/MainScreen.kt
@@ -24,6 +24,7 @@ import com.smashing.app.presentation.notice.navigation.navigateToNotice
 import com.smashing.app.presentation.notice.navigation.noticeGraph
 import com.smashing.app.presentation.profile.navigation.navigateToReview
 import com.smashing.app.presentation.profile.navigation.profileGraph
+import com.smashing.app.presentation.region.navigation.navigateToRegion
 import com.smashing.app.presentation.region.navigation.regionGraph
 import com.smashing.app.presentation.search.navigation.searchGraph
 import com.smashing.app.presentation.signup.navigation.navigateToSignUp
@@ -119,6 +120,16 @@ private fun MainNavHost(
         )
 
         signUpGraph(
+            navigateToRegion = {
+                appState.navController.navigateToRegion(
+                    navOptions = navOptions {
+                        popUpTo<Login> {
+                            inclusive = true
+                        }
+                        launchSingleTop = true
+                    },
+                )
+            },
             navigateToHome = {
                 appState.navController.navigateToHome(
                     navOptions = navOptions {

--- a/app/src/main/java/com/smashing/app/presentation/main/MainTab.kt
+++ b/app/src/main/java/com/smashing/app/presentation/main/MainTab.kt
@@ -17,6 +17,7 @@ import com.smashing.app.R.string.profile
 import com.smashing.app.core.common.navigation.MainTabRoute
 import com.smashing.app.core.common.navigation.Route
 import com.smashing.app.presentation.home.navigation.Home
+import com.smashing.app.presentation.home.navigation.HomeUser
 import com.smashing.app.presentation.matching.navigation.Matching
 import com.smashing.app.presentation.profile.navigation.Profile
 import com.smashing.app.presentation.profile.navigation.ProfileUser
@@ -32,7 +33,7 @@ enum class MainTab(
         selectedIconRes = ic_home_selected,
         unselectedIconRes = ic_home_unselected,
         titleRes = home,
-        route = Home,
+        route = HomeUser,
     ),
     SEARCH(
         selectedIconRes = ic_search_selected,

--- a/app/src/main/java/com/smashing/app/presentation/main/MainTab.kt
+++ b/app/src/main/java/com/smashing/app/presentation/main/MainTab.kt
@@ -16,10 +16,8 @@ import com.smashing.app.R.string.matching_search
 import com.smashing.app.R.string.profile
 import com.smashing.app.core.common.navigation.MainTabRoute
 import com.smashing.app.core.common.navigation.Route
-import com.smashing.app.presentation.home.navigation.Home
 import com.smashing.app.presentation.home.navigation.HomeUser
 import com.smashing.app.presentation.matching.navigation.Matching
-import com.smashing.app.presentation.profile.navigation.Profile
 import com.smashing.app.presentation.profile.navigation.ProfileUser
 import com.smashing.app.presentation.search.navigation.Search
 

--- a/app/src/main/java/com/smashing/app/presentation/region/RegionScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/region/RegionScreen.kt
@@ -36,7 +36,7 @@ import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun RegionRoute(
-    navigateToRegionChange: (Region) -> Unit,
+    navigateToBackStack: (Region) -> Unit,
     navigateUp: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: RegionViewModel = hiltViewModel(),
@@ -50,7 +50,7 @@ fun RegionRoute(
             .collect { sideEffect ->
                 when (sideEffect) {
                     is NavigateUpWithResult -> {
-                        navigateToRegionChange(
+                        navigateToBackStack(
                             Region(
                                 sideEffect.addressName,
                                 sideEffect.cityName,

--- a/app/src/main/java/com/smashing/app/presentation/region/navigation/RegionNavigation.kt
+++ b/app/src/main/java/com/smashing/app/presentation/region/navigation/RegionNavigation.kt
@@ -22,7 +22,7 @@ fun NavGraphBuilder.regionGraph(
     composable<Region> {
         RegionRoute(
             modifier = Modifier.padding(innerPadding),
-            navigateToRegionChange = { region ->
+            navigateToBackStack = { region ->
                 navController.setRegionResult(region)
                 navController.navigateUp()
             },

--- a/app/src/main/java/com/smashing/app/presentation/signup/SignUpContract.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/SignUpContract.kt
@@ -12,6 +12,7 @@ import com.smashing.app.presentation.region.RegionContract
 interface SignUpContract {
     @Immutable
     data class State(
+        val isLoading: Boolean = false,
         val currentStep: Int = 1,
         val nickNameErrorText: String? = null,
         val nickNameConfirmText: String? = null,

--- a/app/src/main/java/com/smashing/app/presentation/signup/SignUpContract.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/SignUpContract.kt
@@ -5,14 +5,10 @@ import com.smashing.app.data.type.GenderType
 import com.smashing.app.data.type.SkillType
 import com.smashing.app.data.type.SportType
 import com.smashing.app.domain.model.Region
-import com.smashing.app.presentation.home.regionchange.RegionChangeContract
-import com.smashing.app.presentation.home.regionchange.RegionChangeUiState
-import com.smashing.app.presentation.region.RegionContract
 
 interface SignUpContract {
     @Immutable
     data class State(
-        val isLoading: Boolean = false,
         val currentStep: Int = 1,
         val nickNameErrorText: String? = null,
         val nickNameConfirmText: String? = null,
@@ -23,12 +19,12 @@ interface SignUpContract {
         val selectedSport: SportType? = null,
         val selectedSkill: SkillType?= null,
         val selectedRegion: Region? = null,
+        val isRegionSelected: Boolean = false,
         val regionLoadState: SignUpUiState = SignUpUiState.Idle,
     )
 
     sealed interface SideEffect {
         data object NavigateToHome: SideEffect
-        data object NavigateToRegion : SideEffect
     }
 
     sealed interface SignUpUiState {

--- a/app/src/main/java/com/smashing/app/presentation/signup/SignUpContract.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/SignUpContract.kt
@@ -4,6 +4,10 @@ import androidx.compose.runtime.Immutable
 import com.smashing.app.data.type.GenderType
 import com.smashing.app.data.type.SkillType
 import com.smashing.app.data.type.SportType
+import com.smashing.app.domain.model.Region
+import com.smashing.app.presentation.home.regionchange.RegionChangeContract
+import com.smashing.app.presentation.home.regionchange.RegionChangeUiState
+import com.smashing.app.presentation.region.RegionContract
 
 interface SignUpContract {
     @Immutable
@@ -17,10 +21,22 @@ interface SignUpContract {
         val selectedGender: GenderType? = null,
         val selectedSport: SportType? = null,
         val selectedSkill: SkillType?= null,
-        val locationInput: String = "",
+        val selectedRegion: Region? = null,
+        val regionLoadState: SignUpUiState = SignUpUiState.Idle,
     )
 
     sealed interface SideEffect {
         data object NavigateToHome: SideEffect
+        data object NavigateToRegion : SideEffect
+    }
+
+    sealed interface SignUpUiState {
+        object Idle : SignUpUiState
+
+        object Success : SignUpUiState
+
+        data class Failure(
+            val msg: String,
+        ) : SignUpUiState
     }
 }

--- a/app/src/main/java/com/smashing/app/presentation/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/SignUpScreen.kt
@@ -49,7 +49,6 @@ import com.smashing.app.core.designsystem.component.sport.SportSkillSelector
 import com.smashing.app.core.extension.clearFocus
 import com.smashing.app.domain.model.Region
 import com.smashing.app.presentation.signup.SignUpContract.SideEffect.NavigateToHome
-import com.smashing.app.presentation.signup.SignUpContract.SideEffect.NavigateToRegion
 import kotlinx.collections.immutable.persistentListOf
 
 private const val MAX_STEP = 6
@@ -78,14 +77,12 @@ fun SignUpRoute(
             .collect { sideEffect ->
                 when (sideEffect) {
                     is NavigateToHome -> navigateToHome()
-                    is NavigateToRegion -> navigateToRegion()
                 }
             }
     }
 
     SignUpScreen(
         uiState = uiState,
-        isLoading = uiState.isLoading,
         nickNameState = viewModel.nickNameState,
         openChatLinkState = viewModel.openChatState,
         selectedGender = uiState.selectedGender,
@@ -95,7 +92,7 @@ fun SignUpRoute(
         onGenderSelected = viewModel::updateSelectedGender,
         onSportSelected = viewModel::updateSelectedSport,
         onSkillSelected = viewModel::updateSelectedSkill,
-        onAddressClick = viewModel::navigateToRegion,
+        onAddressClick = navigateToRegion,
         onBackClick = viewModel::deleteCurrentStep,
         modifier = modifier,
         onBtnClick = {
@@ -111,7 +108,6 @@ fun SignUpRoute(
 @Composable
 private fun SignUpScreen(
     uiState: SignUpContract.State,
-    isLoading: Boolean,
     nickNameState: TextFieldState,
     openChatLinkState: TextFieldState,
     selectedGender: GenderType?,
@@ -128,8 +124,7 @@ private fun SignUpScreen(
 ) {
     val focusManager = LocalFocusManager.current
 
-    BackHandler {
-        if (isLoading) return@BackHandler
+    BackHandler (enabled = uiState.currentStep > 0){
         onBackClick()
     }
 
@@ -196,10 +191,16 @@ private fun SignUpScreen(
                         onSkillSelected = onSkillSelected,
                     )
 
-                    else -> SignUpLocation(
+                    6 -> SignUpLocation(
                         addressText = if (uiState.selectedRegion != null) uiState.selectedRegion.addressName else "주소를 검색해주세요",
                         isAddressExist = if (uiState.selectedRegion != null) true else false,
                         onAddressClick = onAddressClick,
+                    )
+
+                    else -> SignUpNickName(
+                        nickNameState = nickNameState,
+                        nickNameErrorText = uiState.nickNameErrorText,
+                        nickNameConfirmText = uiState.nickNameConfirmText,
                     )
                 }
             } else {
@@ -236,7 +237,6 @@ private fun SignUpScreenPreview() {
 
         SignUpScreen(
             uiState = SignUpContract.State(),
-            isLoading = false,
             isBtnEnabled = true,
             nickNameState = rememberTextFieldState(),
             selectedGender = null,

--- a/app/src/main/java/com/smashing/app/presentation/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/SignUpScreen.kt
@@ -47,13 +47,18 @@ import com.smashing.app.core.designsystem.component.sport.SportSelector
 import com.smashing.app.core.designsystem.component.sport.SportSkillSelector
 import com.smashing.app.core.designsystem.theme.SmashingTheme
 import com.smashing.app.core.extension.clearFocus
+import com.smashing.app.domain.model.Region
 import com.smashing.app.presentation.signup.SignUpContract.SideEffect.NavigateToHome
+import com.smashing.app.presentation.signup.SignUpContract.SideEffect.NavigateToRegion
 import kotlinx.collections.immutable.persistentListOf
 
 private const val MAX_STEP = 6
 
 @Composable
 fun SignUpRoute(
+    regionResult: Region?,
+    onRegionResultConsumed: () -> Unit,
+    navigateToRegion: () -> Unit,
     navigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SignUpViewModel = hiltViewModel(),
@@ -61,11 +66,19 @@ fun SignUpRoute(
     val lifecycleOwner = LocalLifecycleOwner.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    LaunchedEffect(regionResult) {
+        if (regionResult != null) {
+            viewModel.updateSelectedRegion(regionResult)
+            onRegionResultConsumed()
+        }
+    }
+
     LaunchedEffect(Unit) {
         viewModel.sideEffect.flowWithLifecycle(lifecycle = lifecycleOwner.lifecycle)
             .collect { sideEffect ->
                 when (sideEffect) {
                     is NavigateToHome -> navigateToHome()
+                    is NavigateToRegion -> navigateToRegion()
                 }
             }
     }
@@ -81,6 +94,7 @@ fun SignUpRoute(
         onGenderSelected = viewModel::updateSelectedGender,
         onSportSelected = viewModel::updateSelectedSport,
         onSkillSelected = viewModel::updateSelectedSkill,
+        onAddressClick = viewModel::navigateToRegion,
         onBackClick = {},
         modifier = modifier,
         onBtnClick = {
@@ -105,6 +119,7 @@ private fun SignUpScreen(
     onGenderSelected: (GenderType) -> Unit,
     onSportSelected: (SportType) -> Unit,
     onSkillSelected: (SkillType) -> Unit,
+    onAddressClick:() -> Unit,
     onBackClick: () -> Unit,
     onBtnClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -175,7 +190,9 @@ private fun SignUpScreen(
                     )
 
                     else -> SignUpLocation(
-                        onAddressClick = {},
+                        addressText = if (uiState.selectedRegion != null) uiState.selectedRegion.addressName else "주소를 검색해주세요",
+                        isAddressExist = if (uiState.selectedRegion != null) true else false,
+                        onAddressClick = onAddressClick,
                     )
                 }
             } else {
@@ -221,6 +238,7 @@ private fun SignUpScreenPreview() {
             onSportSelected = {},
             selectedSkill = null,
             onSkillSelected = {},
+            onAddressClick = {},
             onBackClick = {},
             onBtnClick = { currentStep = currentStep + 1 },
             modifier = Modifier.background(color = colors.bgCanvas),

--- a/app/src/main/java/com/smashing/app/presentation/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/SignUpScreen.kt
@@ -1,5 +1,6 @@
 package com.smashing.app.presentation.signup
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -45,7 +46,6 @@ import com.smashing.app.presentation.signup.component.location.SignUpLocation
 import com.smashing.app.presentation.signup.component.nickname.SignUpNickName
 import com.smashing.app.core.designsystem.component.sport.SportSelector
 import com.smashing.app.core.designsystem.component.sport.SportSkillSelector
-import com.smashing.app.core.designsystem.theme.SmashingTheme
 import com.smashing.app.core.extension.clearFocus
 import com.smashing.app.domain.model.Region
 import com.smashing.app.presentation.signup.SignUpContract.SideEffect.NavigateToHome
@@ -85,6 +85,7 @@ fun SignUpRoute(
 
     SignUpScreen(
         uiState = uiState,
+        isLoading = uiState.isLoading,
         nickNameState = viewModel.nickNameState,
         openChatLinkState = viewModel.openChatState,
         selectedGender = uiState.selectedGender,
@@ -95,7 +96,7 @@ fun SignUpRoute(
         onSportSelected = viewModel::updateSelectedSport,
         onSkillSelected = viewModel::updateSelectedSkill,
         onAddressClick = viewModel::navigateToRegion,
-        onBackClick = {},
+        onBackClick = viewModel::deleteCurrentStep,
         modifier = modifier,
         onBtnClick = {
             if (uiState.currentStep < MAX_STEP + 1)
@@ -110,6 +111,7 @@ fun SignUpRoute(
 @Composable
 private fun SignUpScreen(
     uiState: SignUpContract.State,
+    isLoading: Boolean,
     nickNameState: TextFieldState,
     openChatLinkState: TextFieldState,
     selectedGender: GenderType?,
@@ -125,6 +127,11 @@ private fun SignUpScreen(
     modifier: Modifier = Modifier,
 ) {
     val focusManager = LocalFocusManager.current
+
+    BackHandler {
+        if (isLoading) return@BackHandler
+        onBackClick()
+    }
 
     Column(
         modifier = modifier
@@ -229,6 +236,7 @@ private fun SignUpScreenPreview() {
 
         SignUpScreen(
             uiState = SignUpContract.State(),
+            isLoading = false,
             isBtnEnabled = true,
             nickNameState = rememberTextFieldState(),
             selectedGender = null,

--- a/app/src/main/java/com/smashing/app/presentation/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/SignUpViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -73,6 +74,12 @@ class SignUpViewModel @Inject constructor(
     fun updateCurrentStep() {
         _uiState.update {
             it.copy(currentStep = it.currentStep + 1)
+        }
+    }
+
+    fun deleteCurrentStep() {
+        _uiState.update {
+            it.copy(currentStep = it.currentStep - 1)
         }
     }
 
@@ -188,7 +195,7 @@ class SignUpViewModel @Inject constructor(
                 gender = selectedGender.name,
                 openChatUrl = openChatState.text.toString(),
                 sportCode = selectedSport.code,
-                tier = selectedSkill.skillCode,
+                experienceRange = selectedSkill.skillCode,
                 region = _uiState.value.selectedRegion.toString(),
             )
             authRepository.postSignUp(request = request)
@@ -205,7 +212,11 @@ class SignUpViewModel @Inject constructor(
                     )
                 }
                 .onFailure { error ->
-                    Timber.tag("SignUp").e("회원가입 실패 $error")
+                    Timber.tag("SignUp").e("회원가입 실패 ${error.message}")
+                    if (error is HttpException) {
+                        val errorBody = error.response()?.errorBody()?.string()
+                        Timber.tag("SignUp").e("SignUp errorBody = $errorBody")
+                    }
                 }
         }
     }

--- a/app/src/main/java/com/smashing/app/presentation/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/SignUpViewModel.kt
@@ -15,10 +15,7 @@ import com.smashing.app.data.type.SportType
 import com.smashing.app.data.remote.dto.auth.PostSignUpRequest
 import com.smashing.app.data.repository.api.AuthRepository
 import com.smashing.app.domain.model.Region
-import com.smashing.app.presentation.home.regionchange.RegionChangeContract
-import com.smashing.app.presentation.home.regionchange.RegionChangeUiState
 import com.smashing.app.presentation.signup.SignUpContract.SideEffect.NavigateToHome
-import com.smashing.app.presentation.signup.SignUpContract.SideEffect.NavigateToRegion
 import com.smashing.app.presentation.signup.SignUpContract.SignUpUiState
 import com.smashing.app.presentation.signup.navigation.SignUp
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -42,7 +39,6 @@ class SignUpViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val kakaoId = savedStateHandle.toRoute<SignUp>().kakaoId
-    private val addressName = savedStateHandle
 
     private val _uiState = MutableStateFlow(SignUpContract.State())
     val uiState = _uiState.asStateFlow()
@@ -61,7 +57,7 @@ class SignUpViewModel @Inject constructor(
             3 -> _uiState.value.isOpenChatValid
             4 -> _uiState.value.selectedSport != null
             5 -> _uiState.value.selectedSkill != null
-            6 -> true
+            6 -> _uiState.value.isRegionSelected
             else -> true
         }
 
@@ -73,13 +69,13 @@ class SignUpViewModel @Inject constructor(
 
     fun updateCurrentStep() {
         _uiState.update {
-            it.copy(currentStep = it.currentStep + 1)
+            it.copy(currentStep = it.currentStep + 1 )
         }
     }
 
     fun deleteCurrentStep() {
         _uiState.update {
-            it.copy(currentStep = it.currentStep - 1)
+            it.copy(currentStep = maxOf(1, it.currentStep - 1))
         }
     }
 
@@ -139,13 +135,11 @@ class SignUpViewModel @Inject constructor(
         _uiState.update { currentState ->
             currentState.copy(
                 selectedRegion = region,
+                isRegionSelected = true,
                 regionLoadState = SignUpUiState.Success,
             )
         }
-    }
 
-    fun navigateToRegion() = viewModelScope.launch {
-        _sideEffect.emit(NavigateToRegion)
     }
 
     fun postOpenchatValid()  = viewModelScope.launch {
@@ -212,11 +206,7 @@ class SignUpViewModel @Inject constructor(
                     )
                 }
                 .onFailure { error ->
-                    Timber.tag("SignUp").e("회원가입 실패 ${error.message}")
-                    if (error is HttpException) {
-                        val errorBody = error.response()?.errorBody()?.string()
-                        Timber.tag("SignUp").e("SignUp errorBody = $errorBody")
-                    }
+                    Timber.tag("SignUp").e("회원가입 실패 ${error}")
                 }
         }
     }

--- a/app/src/main/java/com/smashing/app/presentation/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/SignUpViewModel.kt
@@ -14,7 +14,12 @@ import com.smashing.app.data.type.SkillType
 import com.smashing.app.data.type.SportType
 import com.smashing.app.data.remote.dto.auth.PostSignUpRequest
 import com.smashing.app.data.repository.api.AuthRepository
+import com.smashing.app.domain.model.Region
+import com.smashing.app.presentation.home.regionchange.RegionChangeContract
+import com.smashing.app.presentation.home.regionchange.RegionChangeUiState
 import com.smashing.app.presentation.signup.SignUpContract.SideEffect.NavigateToHome
+import com.smashing.app.presentation.signup.SignUpContract.SideEffect.NavigateToRegion
+import com.smashing.app.presentation.signup.SignUpContract.SignUpUiState
 import com.smashing.app.presentation.signup.navigation.SignUp
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
@@ -36,6 +41,7 @@ class SignUpViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val kakaoId = savedStateHandle.toRoute<SignUp>().kakaoId
+    private val addressName = savedStateHandle
 
     private val _uiState = MutableStateFlow(SignUpContract.State())
     val uiState = _uiState.asStateFlow()
@@ -122,6 +128,19 @@ class SignUpViewModel @Inject constructor(
         }
     }
 
+    fun updateSelectedRegion(region: Region) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                selectedRegion = region,
+                regionLoadState = SignUpUiState.Success,
+            )
+        }
+    }
+
+    fun navigateToRegion() = viewModelScope.launch {
+        _sideEffect.emit(NavigateToRegion)
+    }
+
     fun postOpenchatValid()  = viewModelScope.launch {
         val request = PostOpenchatValidRequest(
             openchatUrl = openChatState.text.toString()
@@ -170,7 +189,7 @@ class SignUpViewModel @Inject constructor(
                 openChatUrl = openChatState.text.toString(),
                 sportCode = selectedSport.code,
                 tier = selectedSkill.skillCode,
-                region = "양천구",
+                region = _uiState.value.selectedRegion.toString(),
             )
             authRepository.postSignUp(request = request)
                 .onSuccess {

--- a/app/src/main/java/com/smashing/app/presentation/signup/component/location/SignUpLocation.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/component/location/SignUpLocation.kt
@@ -2,7 +2,6 @@ package com.smashing.app.presentation.signup.component.location
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -22,15 +21,14 @@ import com.smashing.app.core.extension.noRippleClickable
 import com.smashing.app.presentation.signup.component.SignUpTitle
 import com.smashing.app.R.string.sign_up_location_title
 import com.smashing.app.R.string.sign_up_location_subtitle
-import com.smashing.app.R.string.sign_up_location_placeholder
 
 
 @Composable
 fun SignUpLocation(
+    addressText: String ,
+    isAddressExist: Boolean,
     onAddressClick: () -> Unit,
     modifier: Modifier = Modifier,
-    addressText: String = stringResource(sign_up_location_placeholder),
-    isAddressExist: Boolean = false,
 ) {
     Column(
         modifier = modifier,
@@ -71,8 +69,10 @@ fun SignUpLocation(
 private fun SignUpLocationPreview() {
     SmashingAndroidTheme {
         SignUpLocation(
+            addressText = "주소를 검색해주세요",
+            isAddressExist = false,
             onAddressClick = {},
-            modifier = Modifier.background(color = colors.bgCanvas),
+            modifier = Modifier.background(color = colors.bgCanvas)
         )
     }
 }

--- a/app/src/main/java/com/smashing/app/presentation/signup/navigation/SignUpNavigation.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/navigation/SignUpNavigation.kt
@@ -7,6 +7,8 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.smashing.app.presentation.region.navigation.getRegionResult
+import com.smashing.app.presentation.region.navigation.removeRegionResult
 import com.smashing.app.presentation.signup.SignUpRoute
 import kotlinx.serialization.Serializable
 
@@ -16,11 +18,17 @@ fun NavController.navigateToSignUp(
 ) = navigate(SignUp(kakaoId), navOptions)
 
 fun NavGraphBuilder.signUpGraph(
+    navigateToRegion: () -> Unit,
     navigateToHome: () -> Unit,
     innerPadding: PaddingValues,
 ) {
-    composable<SignUp> {
+    composable<SignUp> {backStackEntry ->
+        val savedStateHandle = backStackEntry.savedStateHandle
+
         SignUpRoute(
+            regionResult = savedStateHandle.getRegionResult(),
+            onRegionResultConsumed = savedStateHandle::removeRegionResult,
+            navigateToRegion = navigateToRegion,
             navigateToHome = navigateToHome,
             modifier = Modifier.padding(innerPadding),
         )

--- a/app/src/main/java/com/smashing/app/presentation/signup/navigation/SignUpNavigation.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/navigation/SignUpNavigation.kt
@@ -1,7 +1,6 @@
 package com.smashing.app.presentation.signup.navigation
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -30,7 +29,7 @@ fun NavGraphBuilder.signUpGraph(
             onRegionResultConsumed = savedStateHandle::removeRegionResult,
             navigateToRegion = navigateToRegion,
             navigateToHome = navigateToHome,
-            modifier = Modifier.padding(innerPadding),
+            modifier = Modifier,
         )
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #91

## Work Description ✏️
- 회원가입 주소 api를 연동했습니다.

## Screenshot 📸
https://github.com/user-attachments/assets/7df763f7-6d22-4cea-a7f4-d99f0ce77cbd


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 혹시 안되는거 있으면 바로 말씀해주세요!!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 가입 프로세스에 지역 선택 기능 추가
  * 가입 중 로딩 상태 표시 추가

* **개선 사항**
  * 경력 수준 선택 옵션 업데이트
  * 지역 선택 후 가입 화면으로 돌아가기 기능 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->