### PR TITLE
[FEAT/#138] Home 내비게이션추가 및 드롭다운 수정

### DIFF
--- a/app/src/main/java/com/smashing/app/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/HomeScreen.kt
@@ -77,6 +77,7 @@ fun HomeRoute(
     navigateToTierInfo: (TierInfoStyle, SportType) -> Unit,
     navigateToRanking: () -> Unit,
     navigateToMatchingAccepted: () -> Unit,
+    navigateToUserProfile: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
@@ -101,6 +102,7 @@ fun HomeRoute(
         },
         navigateToRanking = navigateToRanking,
         navigateToMatchingAccepted = navigateToMatchingAccepted,
+        navigateToUserProfile = navigateToUserProfile,
         modifier = modifier,
     )
 }
@@ -113,6 +115,7 @@ private fun HomeScreen(
     navigateToTierInfo: () -> Unit,
     navigateToRanking: () -> Unit,
     navigateToMatchingAccepted: () -> Unit,
+    navigateToUserProfile: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val activeUserProfile = uiState.activeUserProfile ?: run {
@@ -281,6 +284,9 @@ private fun HomeScreen(
                             ) { cardState ->
                                 MatchingCard(
                                     cardState = cardState,
+                                    modifier = Modifier.noRippleClickable(
+                                        onClick = { navigateToUserProfile(cardState.userId) }
+                                    )
                                 )
                             }
                         }
@@ -339,7 +345,7 @@ private fun HomeScreen(
                             tier = ranker.tier,
                             lp = ranker.lp,
                             userId = ranker.userId,
-                            onClick = {},
+                            onClick = { navigateToUserProfile(ranker.userId) },
                         )
                     }
                 }
@@ -668,6 +674,7 @@ private fun HomeScreenPreview() {
         navigateToTierInfo = {},
         navigateToRanking = {},
         navigateToMatchingAccepted = {},
+        navigateToUserProfile = {},
     )
 }
 
@@ -706,6 +713,6 @@ private fun HomeScreenEmptyValuePreview() {
         navigateToTierInfo = {},
         navigateToRanking = {},
         navigateToMatchingAccepted = {},
-
+        navigateToUserProfile = {},
     )
 }

--- a/app/src/main/java/com/smashing/app/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/HomeScreen.kt
@@ -76,6 +76,7 @@ fun HomeRoute(
     navigateToRegionChange: () -> Unit,
     navigateToTierInfo: (TierInfoStyle, SportType) -> Unit,
     navigateToRanking: () -> Unit,
+    navigateToMatchingAccepted: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
@@ -99,6 +100,7 @@ fun HomeRoute(
             )
         },
         navigateToRanking = navigateToRanking,
+        navigateToMatchingAccepted = navigateToMatchingAccepted,
         modifier = modifier,
     )
 }
@@ -110,6 +112,7 @@ private fun HomeScreen(
     navigateToRegionChange: () -> Unit,
     navigateToTierInfo: () -> Unit,
     navigateToRanking: () -> Unit,
+    navigateToMatchingAccepted: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val activeUserProfile = uiState.activeUserProfile ?: run {
@@ -220,7 +223,7 @@ private fun HomeScreen(
                             color = SmashingTheme.colors.txtTertiary,
                             modifier = Modifier
                                 .noRippleClickable(
-                                    onClick = {}
+                                    onClick = navigateToMatchingAccepted
                                 ),
                         )
                     }
@@ -664,6 +667,7 @@ private fun HomeScreenPreview() {
         navigateToRegionChange = {},
         navigateToTierInfo = {},
         navigateToRanking = {},
+        navigateToMatchingAccepted = {},
     )
 }
 
@@ -701,5 +705,7 @@ private fun HomeScreenEmptyValuePreview() {
         navigateToRegionChange = {},
         navigateToTierInfo = {},
         navigateToRanking = {},
+        navigateToMatchingAccepted = {},
+
     )
 }

--- a/app/src/main/java/com/smashing/app/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/HomeScreen.kt
@@ -78,6 +78,7 @@ fun HomeRoute(
     navigateToRanking: () -> Unit,
     navigateToMatchingAccepted: () -> Unit,
     navigateToUserProfile: (String) -> Unit,
+    navigateToSportAdd: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
@@ -103,6 +104,8 @@ fun HomeRoute(
         navigateToRanking = navigateToRanking,
         navigateToMatchingAccepted = navigateToMatchingAccepted,
         navigateToUserProfile = navigateToUserProfile,
+        navigateToSportAdd = navigateToSportAdd,
+        onSportsChipClick = viewModel::fetchSelectSportProfile,
         modifier = modifier,
     )
 }
@@ -116,6 +119,8 @@ private fun HomeScreen(
     navigateToRanking: () -> Unit,
     navigateToMatchingAccepted: () -> Unit,
     navigateToUserProfile: (String) -> Unit,
+    navigateToSportAdd: () -> Unit,
+    onSportsChipClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val activeUserProfile = uiState.activeUserProfile ?: run {
@@ -167,13 +172,17 @@ private fun HomeScreen(
             maxLp = uiState.activeUserProfile.maxLp,
             winCount = uiState.activeUserProfile.wins,
             loseCount = uiState.activeUserProfile.losses,
-            onSportChipClick = {
-                // 스포츠 변경 로직 (필요시 추가)
+            onSportChipClick = { profileId ->
+                onSportsChipClick(profileId)
                 isDropdownExpanded = false
             },
-            onSportAddClick = {
-                // 스포츠 추가 로직 (필요시 추가)
-                isDropdownExpanded = false
+            onSportAddClick = if (uiState.allUserProfiles.size >= 3) {
+                null
+            } else {
+                {
+                    navigateToSportAdd()
+                    isDropdownExpanded = false
+                }
             },
             onTierClick = {
                 navigateToTierInfo()
@@ -675,6 +684,8 @@ private fun HomeScreenPreview() {
         navigateToRanking = {},
         navigateToMatchingAccepted = {},
         navigateToUserProfile = {},
+        onSportsChipClick = {},
+        navigateToSportAdd = {},
     )
 }
 
@@ -714,5 +725,7 @@ private fun HomeScreenEmptyValuePreview() {
         navigateToRanking = {},
         navigateToMatchingAccepted = {},
         navigateToUserProfile = {},
+        navigateToSportAdd = {},
+        onSportsChipClick = {},
     )
 }

--- a/app/src/main/java/com/smashing/app/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/HomeViewModel.kt
@@ -107,26 +107,33 @@ class HomeViewModel @Inject constructor(
 
     fun fetchSelectSportProfile(profileId: String) {
         val currentState = uiState.value
-        if (currentState.activeUserProfile?.profileId == profileId) return
+        val currentActiveProfile = currentState.activeUserProfile ?: return
+        if (currentActiveProfile.profileId == profileId) return
+
+        val selectedProfile = currentState.allUserProfiles.find { it.profileId == profileId } ?: return
 
         val optimisticList = currentState.allUserProfiles.map { profile ->
-            if (profile.profileId == profileId) {
-                profile.copy(isActive = true)
-            } else {
-                profile.copy(isActive = false)
-            }
+            profile.copy(isActive = profile.profileId == profileId)
         }.toImmutableList()
 
+        val optimisticActiveProfile = currentActiveProfile.copy(
+            profileId = selectedProfile.profileId,
+            sportType = selectedProfile.sportCode,
+        )
+
         _uiState.update {
-            it.copy(allUserProfiles = optimisticList)
+            it.copy(
+                allUserProfiles = optimisticList,
+                activeUserProfile = optimisticActiveProfile,
+            )
         }
 
         viewModelScope.launch {
             myRepository.switchActiveMyProfile(profileId)
                 .onSuccess {
-                    fetchMyTierProfile()  // 프로필 정보 새로고침
-                    fetchRegionRankerList()  // 랭킹 새로고침 (스포츠 변경 시 필요할 수 있음)
-                    fetchRecommendedUserList()  // 추천 유저 새로고침
+                    fetchMyTierProfile()
+                    fetchRegionRankerList()
+                    fetchRecommendedUserList()
                 }
                 .onFailure { throwable ->
                     Timber.tag("HomeViewModel").e(throwable, "Failed to switch sport profile")

--- a/app/src/main/java/com/smashing/app/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/HomeViewModel.kt
@@ -105,6 +105,36 @@ class HomeViewModel @Inject constructor(
             }
     }
 
+    fun fetchSelectSportProfile(profileId: String) {
+        val currentState = uiState.value
+        if (currentState.activeUserProfile?.profileId == profileId) return
+
+        val optimisticList = currentState.allUserProfiles.map { profile ->
+            if (profile.profileId == profileId) {
+                profile.copy(isActive = true)
+            } else {
+                profile.copy(isActive = false)
+            }
+        }.toImmutableList()
+
+        _uiState.update {
+            it.copy(allUserProfiles = optimisticList)
+        }
+
+        viewModelScope.launch {
+            myRepository.switchActiveMyProfile(profileId)
+                .onSuccess {
+                    fetchMyTierProfile()  // 프로필 정보 새로고침
+                    fetchRegionRankerList()  // 랭킹 새로고침 (스포츠 변경 시 필요할 수 있음)
+                    fetchRecommendedUserList()  // 추천 유저 새로고침
+                }
+                .onFailure { throwable ->
+                    Timber.tag("HomeViewModel").e(throwable, "Failed to switch sport profile")
+                    fetchMyTierProfile()
+                }
+        }
+    }
+
     private fun createDummyMatchedUser(): DummyMatchedUser? {
         return DummyMatchedUser(
             userId = "matchedUser1",

--- a/app/src/main/java/com/smashing/app/presentation/home/component/HomeDropdown.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/component/HomeDropdown.kt
@@ -65,12 +65,12 @@ fun HomeDropdown(
     maxLp: Int,
     winCount: Int,
     loseCount: Int,
-    onSportChipClick: () -> Unit,
-    onSportAddClick: () -> Unit,
+    onSportChipClick: (String) -> Unit,
     onTierClick: () -> Unit,
     onDismiss: () -> Unit,
     triggerHeight: Dp,
     modifier: Modifier = Modifier,
+    onSportAddClick: (() -> Unit)? = null,
     isExpanded: Boolean = false,
 ) {
     val density = LocalDensity.current
@@ -158,14 +158,16 @@ fun HomeDropdown(
                         SmashingChip(
                             text = sport.sportCode.sportName,
                             style = if (sport.isActive) ChipStyle.ACTIVE else ChipStyle.DISABLED,
-                            onClick = onSportChipClick,
+                            onClick = { onSportChipClick(sport.profileId) },  // profileId 전달
                         )
                     }
-                    SmashingChip(
-                        icon = ImageVector.vectorResource(ic_plus),
-                        style = ChipStyle.DISABLED,
-                        onClick = onSportAddClick,
-                    )
+                    if (onSportAddClick != null) {
+                        SmashingChip(
+                            icon = ImageVector.vectorResource(ic_plus),
+                            style = ChipStyle.DISABLED,
+                            onClick = onSportAddClick,
+                        )
+                    }
                 }
 
                 Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/smashing/app/presentation/home/component/HomeDropdown.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/component/HomeDropdown.kt
@@ -158,7 +158,7 @@ fun HomeDropdown(
                         SmashingChip(
                             text = sport.sportCode.sportName,
                             style = if (sport.isActive) ChipStyle.ACTIVE else ChipStyle.DISABLED,
-                            onClick = { onSportChipClick(sport.profileId) },  // profileId 전달
+                            onClick = { onSportChipClick(sport.profileId) },
                         )
                     }
                     if (onSportAddClick != null) {

--- a/app/src/main/java/com/smashing/app/presentation/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/navigation/HomeNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.smashing.app.core.common.navigation.MainTabRoute
 import com.smashing.app.core.common.navigation.Route
+import com.smashing.app.presentation.addsports.navigation.navigateToAddSports
 import com.smashing.app.presentation.home.HomeRoute
 import com.smashing.app.presentation.home.regionchange.RegionChangeRoute
 import com.smashing.app.presentation.matching.navigation.navigateToMatching
@@ -52,6 +53,7 @@ fun NavGraphBuilder.homeGraph(
                 navigateToUserProfile = { userId ->
                     navController.navigateToUserProfile(userId = userId)
                 },
+                navigateToSportAdd = navController::navigateToAddSports,
             )
         }
 

--- a/app/src/main/java/com/smashing/app/presentation/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/navigation/HomeNavigation.kt
@@ -14,6 +14,7 @@ import com.smashing.app.presentation.home.regionchange.RegionChangeRoute
 import com.smashing.app.presentation.matching.navigation.navigateToMatching
 import com.smashing.app.presentation.matching.type.MatchingType
 import com.smashing.app.presentation.notice.navigation.navigateToNotice
+import com.smashing.app.presentation.profile.navigation.navigateToUserProfile
 import com.smashing.app.presentation.ranking.navigation.navigateToRanking
 import com.smashing.app.presentation.region.navigation.getRegionResult
 import com.smashing.app.presentation.region.navigation.navigateToRegion
@@ -47,6 +48,9 @@ fun NavGraphBuilder.homeGraph(
                 },
                 navigateToMatchingAccepted = {
                     navController.navigateToMatching(initTab = MatchingType.ACCEPTED)
+                },
+                navigateToUserProfile = { userId ->
+                    navController.navigateToUserProfile(userId = userId)
                 },
             )
         }

--- a/app/src/main/java/com/smashing/app/presentation/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/navigation/HomeNavigation.kt
@@ -11,6 +11,8 @@ import com.smashing.app.core.common.navigation.MainTabRoute
 import com.smashing.app.core.common.navigation.Route
 import com.smashing.app.presentation.home.HomeRoute
 import com.smashing.app.presentation.home.regionchange.RegionChangeRoute
+import com.smashing.app.presentation.matching.navigation.navigateToMatching
+import com.smashing.app.presentation.matching.type.MatchingType
 import com.smashing.app.presentation.notice.navigation.navigateToNotice
 import com.smashing.app.presentation.ranking.navigation.navigateToRanking
 import com.smashing.app.presentation.region.navigation.getRegionResult
@@ -42,6 +44,9 @@ fun NavGraphBuilder.homeGraph(
                 navigateToRanking = navController::navigateToRanking,
                 navigateToTierInfo = { tierInfoStyle, sportType ->
                     navController.navigateToTierInfo(tierName = tierInfoStyle.name, sportName = sportType.code)
+                },
+                navigateToMatchingAccepted = {
+                    navController.navigateToMatching(initTab = MatchingType.ACCEPTED)
                 },
             )
         }

--- a/app/src/main/java/com/smashing/app/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/main/MainScreen.kt
@@ -177,7 +177,7 @@ private fun MainNavHost(
 
         rankingGraph(
             innerPadding = innerPadding,
-            navigateUp = appState.navController::navigateUp,
+            navController = appState.navController,
         )
 
         tierInfoGraph(

--- a/app/src/main/java/com/smashing/app/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/main/MainScreen.kt
@@ -22,7 +22,6 @@ import com.smashing.app.presentation.main.component.MainBottomBar
 import com.smashing.app.presentation.matching.navigation.Matching
 import com.smashing.app.presentation.matching.navigation.matchingGraph
 import com.smashing.app.presentation.matching.navigation.navigateToMatching
-import com.smashing.app.presentation.matching.type.MatchingType
 import com.smashing.app.presentation.notice.navigation.noticeGraph
 import com.smashing.app.presentation.profile.navigation.navigateToReview
 import com.smashing.app.presentation.profile.navigation.profileGraph

--- a/app/src/main/java/com/smashing/app/presentation/ranking/navigation/rankingNavigation.kt
+++ b/app/src/main/java/com/smashing/app/presentation/ranking/navigation/rankingNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.smashing.app.core.common.navigation.Route
+import com.smashing.app.presentation.profile.navigation.navigateToUserProfile
 import com.smashing.app.presentation.ranking.RankingRoute
 import kotlinx.serialization.Serializable
 
@@ -15,15 +16,16 @@ fun NavController.navigateToRanking(
 ) = navigate(RankingPage, navOptions)
 
 fun NavGraphBuilder.rankingGraph(
-    navigateUp: () -> Unit,
+    navController: NavController,
     innerPadding: PaddingValues,
 ) {
     composable<RankingPage> {
         RankingRoute(
             modifier = Modifier,
-            navigateUp = navigateUp,
-            //TODO 클릭했을 때, 대상의 프로필로 이동
-            navigateToProfile = {},
+            navigateUp = navController::navigateUp,
+            navigateToProfile = { userId ->
+                navController.navigateToUserProfile(userId = userId)
+            },
         )
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #138 

## Work Description ✏️
- Home 네비게이션 연결
- 드롭다운 칩 수정

## Screenshot 📸
https://github.com/user-attachments/assets/d435997f-f0fa-4f7a-b80a-bb758ed859f5



## Uncompleted Tasks 😅

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 홈 화면의 매칭 버튼에서 수락된 매칭 목록에 직접 접근 가능
  * 매칭 카드와 랭킹 목록에서 사용자 프로필로 빠르게 이동
  * 홈 화면에서 새로운 스포츠 추가 옵션 활성화
  * 스포츠 프로필 선택 및 활성 프로필 전환 기능 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->