### PR TITLE
[FIX/#181] Home 추천 유저 스크롤 초기화

### DIFF
--- a/app/src/main/java/com/smashing/app/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/HomeScreen.kt
@@ -176,7 +176,7 @@ private fun HomeScreen(
     updateBottomBar: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     recommendedUserListState: LazyListState = rememberLazyListState(),
-    ) {
+) {
     val activeUserProfile = uiState.activeUserProfile ?: run {
         // TODO: 로딩 또는 에러 UI 표시
         return

--- a/app/src/main/java/com/smashing/app/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/HomeScreen.kt
@@ -17,8 +17,10 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -105,12 +107,18 @@ fun HomeRoute(
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val recommendedUserListState = rememberLazyListState()
 
     LaunchedEffect(Unit) {
         viewModel.fetchMyTierProfile()
         viewModel.fetchRegionRankerList()
         viewModel.fetchRecommendedUserList()
         viewModel.fetchMatchedUser()
+    }
+
+
+    LaunchedEffect(uiState.recommendedUserList) {
+        recommendedUserListState.scrollToItem(0)
     }
 
     // TODO 토스트 예시
@@ -137,6 +145,7 @@ fun HomeRoute(
         navigateToConfirm = navigateToConfirm,
         onSportsChipClick = viewModel::fetchSelectSportProfile,
         updateBottomBar = updateBottomBar,
+        recommendedUserListState = recommendedUserListState,
         modifier = modifier,
     )
 }
@@ -166,7 +175,8 @@ private fun HomeScreen(
     onSportsChipClick: (String) -> Unit,
     updateBottomBar: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
-) {
+    recommendedUserListState: LazyListState = rememberLazyListState(),
+    ) {
     val activeUserProfile = uiState.activeUserProfile ?: run {
         // TODO: 로딩 또는 에러 UI 표시
         return
@@ -372,6 +382,7 @@ private fun HomeScreen(
                     }
                     if (uiState.recommendedUserList.isNotEmpty()) {
                         LazyRow(
+                            state = recommendedUserListState,
                             modifier = Modifier
                                 .fillMaxWidth(),
                             horizontalArrangement = Arrangement.spacedBy(16.dp),


### PR DESCRIPTION
## Related issue 🛠
- closed #181 

## Work Description ✏️
- Home 추천 유저 스크롤 초기화

## Screenshot 📸

https://github.com/user-attachments/assets/cdfc907a-c5b4-4109-a757-29902a63620f


## Uncompleted Tasks 😅
- [ ] Task1

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 추천 사용자 목록의 스크롤 동작이 개선되었습니다. 데이터 변경 시 목록이 자동으로 맨 위로 스크롤되어 최신 콘텐츠를 더 쉽게 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->