### PR TITLE
[UI/#206] 후기 텍스트 길때 태그 밀림 현상 해결

### DIFF
--- a/app/src/main/java/com/smashing/app/core/util/ConvertTimeProvider.kt
+++ b/app/src/main/java/com/smashing/app/core/util/ConvertTimeProvider.kt
@@ -37,13 +37,19 @@ object ConvertTimeProvider {
 
         return convertedTime
     }
+
     fun calculateNotificationTime(timeString: String): String {
         return runCatching {
             val cleanTime = timeString.replace(" ", "T")
 
-            val localDateTime = LocalDateTime.parse(cleanTime, DateTimeFormatter.ISO_DATE_TIME)
+            val localDateTime = try {
+                LocalDateTime.parse(cleanTime, DateTimeFormatter.ISO_DATE_TIME)
+            } catch (e: Exception) {
+                val fallbackFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                LocalDateTime.parse(timeString, fallbackFormatter)
+            }
 
-            val createdTime = localDateTime.atZone(ZoneId.of("UTC")).toInstant()
+            val createdTime = localDateTime.atZone(ZoneId.of("Asia/Seoul")).toInstant()
             val now = Instant.now()
 
             val duration = Duration.between(createdTime, now)
@@ -62,7 +68,9 @@ object ConvertTimeProvider {
                 days < 365 -> "${days / 30}달 전"
                 else -> "${days / 365}년 전"
             }
-        }.getOrElse { "" }
+        }.getOrElse {
+            ""
+        }
     }
 
     private fun parseToInstant(time: String): Instant? =

--- a/app/src/main/java/com/smashing/app/core/util/ConvertTimeProvider.kt
+++ b/app/src/main/java/com/smashing/app/core/util/ConvertTimeProvider.kt
@@ -78,7 +78,7 @@ object ConvertTimeProvider {
             OffsetDateTime.parse(time).toInstant()
         }
             .recoverCatching {
-                LocalDateTime.parse(time).atZone(ZoneId.of("UTC")).toInstant()
+                LocalDateTime.parse(time).atZone(ZoneId.of("Asia/Seoul")).toInstant()
             }
             .getOrNull()
 }

--- a/app/src/main/java/com/smashing/app/presentation/confirmreview/component/ConfirmReviewCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/confirmreview/component/ConfirmReviewCard.kt
@@ -2,6 +2,7 @@ package com.smashing.app.presentation.confirmreview.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
@@ -19,6 +20,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.smashing.app.R
@@ -50,7 +52,8 @@ fun ConfirmReviewCard(
                 shape = RoundedCornerShape(8.dp),
             )
             .padding(vertical = 24.dp, horizontal = 16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top
     ) {
         ReviewHeader(
             iconId = iconId,
@@ -58,29 +61,40 @@ fun ConfirmReviewCard(
         )
         Spacer(modifier = Modifier.height(40.dp))
 
+
         if (hasReviewText) {
             Text(
                 text = reviewText,
                 style = SmashingTheme.typography.md.medium16,
                 color = SmashingTheme.colors.txtSecondary,
                 textAlign = TextAlign.Left,
-                modifier = Modifier.fillMaxWidth()
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f, fill = false)
             )
         }
-        
+
         if (hasReviewText) {
             Spacer(modifier = Modifier.height(40.dp))
         }
 
         if (isEmptyReview) {
-            Text(
-                text = nickname + "님이 구체적인 후기는 남기지 않았어요",
-                style = SmashingTheme.typography.md.regular16,
-                color = SmashingTheme.colors.txtTertiary,
-                textAlign = TextAlign.Center
-            )
-        }
+            Box(
+                modifier = Modifier
+                    .weight(1f) // 빈 공간 꽉 채워서 중앙 정렬
+                    .fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = nickname + "님이 구체적인 후기는 남기지 않았어요",
+                    style = SmashingTheme.typography.md.regular16,
+                    color = SmashingTheme.colors.txtTertiary,
+                    textAlign = TextAlign.Center
+                )
+            }
 
+        }
         if (hasTags) {
             FlowRow(
                 modifier = Modifier.fillMaxWidth(),
@@ -97,7 +111,6 @@ fun ConfirmReviewCard(
         }
     }
 }
-
 @Composable
 private fun ReviewHeader(
     iconId: Int,

--- a/app/src/main/java/com/smashing/app/presentation/confirmreview/component/ConfirmReviewCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/confirmreview/component/ConfirmReviewCard.kt
@@ -42,7 +42,7 @@ fun ConfirmReviewCard(
     val hasReviewText = !reviewText.isNullOrBlank()
     val hasTags = tags.isNotEmpty()
     val isEmptyReview = !hasReviewText && !hasTags
-    
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -69,7 +69,10 @@ fun ConfirmReviewCard(
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .weight(1f, fill = false)
+                    .weight(
+                        weight = 1f,
+                        fill = false
+                    )
             )
         }
 

--- a/app/src/main/java/com/smashing/app/presentation/confirmreview/component/ConfirmReviewCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/confirmreview/component/ConfirmReviewCard.kt
@@ -42,8 +42,7 @@ fun ConfirmReviewCard(
     val hasReviewText = !reviewText.isNullOrBlank()
     val hasTags = tags.isNotEmpty()
     val isEmptyReview = !hasReviewText && !hasTags
-
-
+    
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -60,7 +59,6 @@ fun ConfirmReviewCard(
             rating = rating,
         )
         Spacer(modifier = Modifier.height(40.dp))
-
 
         if (hasReviewText) {
             Text(
@@ -82,7 +80,7 @@ fun ConfirmReviewCard(
         if (isEmptyReview) {
             Box(
                 modifier = Modifier
-                    .weight(1f) 
+                    .weight(1f)
                     .fillMaxWidth(),
                 contentAlignment = Alignment.Center
             ) {
@@ -93,7 +91,6 @@ fun ConfirmReviewCard(
                     textAlign = TextAlign.Center
                 )
             }
-
         }
         if (hasTags) {
             FlowRow(
@@ -111,6 +108,7 @@ fun ConfirmReviewCard(
         }
     }
 }
+
 @Composable
 private fun ReviewHeader(
     iconId: Int,

--- a/app/src/main/java/com/smashing/app/presentation/confirmreview/component/ConfirmReviewCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/confirmreview/component/ConfirmReviewCard.kt
@@ -82,7 +82,7 @@ fun ConfirmReviewCard(
         if (isEmptyReview) {
             Box(
                 modifier = Modifier
-                    .weight(1f) // 빈 공간 꽉 채워서 중앙 정렬
+                    .weight(1f) 
                     .fillMaxWidth(),
                 contentAlignment = Alignment.Center
             ) {


### PR DESCRIPTION
## Related issue 🛠
- closed #206

## Work Description ✏️
- 후기가길면 태그가 밀려 안보이는 현상을 해결했습니다

## Screenshot 📸
<img src="" width="360"/>
<img width="271" height="563" alt="스크린샷 2026-01-23 오전 8 25 06" src="https://github.com/user-attachments/assets/5287a9ec-24a2-4836-8dff-da07569a9cd7" />
<img width="277" height="545" alt="스크린샷 2026-01-23 오전 8 25 33" src="https://github.com/user-attachments/assets/c8e99e4a-0f9a-4cb4-9631-b2a77cd55a7a" />


## Uncompleted Tasks 😅
-N/A

## To Reviewers 📢
댕큐베리마치

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 긴 리뷰 텍스트가 화면을 벗어날 때 적절히 말줄임표로 표시되도록 개선
  * 리뷰가 없는 경우 닉네임 메시지가 화면 중앙에 정렬되도록 수정

* **UI 개선**
  * 리뷰 카드 레이아웃 정렬 및 간격 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->