### PR TITLE
[MOD/#219] Ranking Screen 파라미터 및 패딩 값 수정

### DIFF
--- a/app/src/main/java/com/smashing/app/presentation/ranking/RankingScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/ranking/RankingScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -195,10 +194,7 @@ private fun RankingScreen(
         }
         if (uiState.userInfo != null) {
             MyRanking(
-                userId = uiState.userInfo.userId,
-                nickname = uiState.userInfo.nickname,
-                tier = uiState.userInfo.tier,
-                lp = uiState.userInfo.lp,
+                myRank = uiState.userInfo,
                 modifier = Modifier
                     .fillMaxWidth()
                     .align(Alignment.BottomCenter)
@@ -224,10 +220,7 @@ private fun RankingScreen(
 
 @Composable
 private fun MyRanking(
-    userId: String,
-    nickname: String,
-    tier: TierType,
-    lp: Int,
+    myRank: UserRank,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -249,9 +242,9 @@ private fun MyRanking(
 
     ) {
         UrlImage(
-            placeholderDrawable = ProfileImageProvider.getTempImg(nickname),
+            placeholderDrawable = ProfileImageProvider.getTempImg(myRank.nickname),
             modifier = Modifier
-                .height(40.dp)
+                .size(40.dp)
                 .aspectRatio(1f)
                 .clip(CircleShape),
         )
@@ -259,19 +252,18 @@ private fun MyRanking(
         Spacer(modifier = Modifier.width(10.dp))
 
         Column(
-            modifier = Modifier,
             horizontalAlignment = Alignment.Start,
         ) {
             Text(
-                text = nickname,
+                text = myRank.nickname,
                 style = typography.sm.medium14,
                 color = colors.txtPrimary,
             )
             Text(
                 text = stringResource(
                     ranking_tier_with_lp,
-                    tier.tierName,
-                    lp,
+                    myRank.tier.tierName,
+                    myRank.lp,
                 ),
                 style = typography.xs.regular12,
                 color = colors.txtTertiary,
@@ -281,10 +273,10 @@ private fun MyRanking(
         Spacer(modifier = Modifier.weight(1f))
 
         Image(
-            painter = painterResource(id = tier.img()),
+            painter = painterResource(id = myRank.tier.img()),
             contentDescription = null,
             modifier = Modifier
-                .height(40.dp)
+                .size(40.dp)
                 .aspectRatio(1f)
         )
     }

--- a/app/src/main/java/com/smashing/app/presentation/ranking/RankingScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/ranking/RankingScreen.kt
@@ -120,7 +120,7 @@ private fun RankingScreen(
 
             Ranker(
                 rankerList = uiState.topRankingList,
-                myNickname = uiState.userInfo?.nickname,
+                myUserId = uiState.userInfo?.userId,
                 navigateToProfile = navigateToProfile,
                 navigateToMyProfile = navigateToMyProfile,
             )

--- a/app/src/main/java/com/smashing/app/presentation/ranking/RankingScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/ranking/RankingScreen.kt
@@ -158,7 +158,7 @@ private fun RankingScreen(
                             tier = user.tier,
                             lp = user.lp,
                             onClick = {
-                                if (user.nickname != uiState.userInfo?.nickname) {
+                                if (user.userId != uiState.userInfo?.userId) {
                                     navigateToProfile(user.userId)
                                 } else {
                                     navigateToMyProfile()

--- a/app/src/main/java/com/smashing/app/presentation/ranking/RankingViewModel.kt
+++ b/app/src/main/java/com/smashing/app/presentation/ranking/RankingViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.smashing.app.data.model.rank.UserRank
 import com.smashing.app.data.repository.api.RankingRepository
+import com.smashing.app.data.repository.api.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,7 +16,8 @@ import javax.inject.Inject
 @HiltViewModel
 class RankingViewModel @Inject constructor(
     private val rankingRepository: RankingRepository,
-) : ViewModel() {
+    private val userRepository: UserRepository,
+    ) : ViewModel() {
     private val _uiState = MutableStateFlow(RankingContract.State())
     val uiState = _uiState.asStateFlow()
 
@@ -29,6 +31,8 @@ class RankingViewModel @Inject constructor(
         rankingRepository.getRankingList()
             .onSuccess { rankingData ->
                 val userRankList = rankingData.topUsers
+                val storedUserId = userRepository.getUserId()
+
                 _uiState.update { currentState ->
                     currentState.copy(
                         rankingUiState = RankingUiState.Success,
@@ -37,6 +41,7 @@ class RankingViewModel @Inject constructor(
                         restRankingList = userRankList.drop(3).toImmutableList(),
                         userInfo = rankingData.myRank?.let { user ->
                             UserRank(
+                                userId = storedUserId ?: "",
                                 nickname = user.nickname,
                                 tier = user.tierType,
                                 lp = user.lp,

--- a/app/src/main/java/com/smashing/app/presentation/ranking/component/RankerItem.kt
+++ b/app/src/main/java/com/smashing/app/presentation/ranking/component/RankerItem.kt
@@ -60,9 +60,9 @@ private const val RANKER_OTHER_WIDTH_RATIO = 0.33f
 @Composable
 fun Ranker(
     rankerList: ImmutableList<UserRank>?,
-    navigateToProfile: (String) -> Unit,
     myUserId: String?,
     navigateToMyProfile: () -> Unit,
+    navigateToProfile: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(
@@ -77,12 +77,18 @@ fun Ranker(
         val firstWidth = contentAreaWidth * RANKER_FIRST_WIDTH_RATIO + centerExtraWidth
         val otherWidth = contentAreaWidth * RANKER_OTHER_WIDTH_RATIO
 
+        val onProfileClick: (String) -> Unit = { userId ->
+            if (userId != myUserId) {
+                navigateToProfile(userId)
+            } else {
+                navigateToMyProfile()
+            }
+        }
+
         RankerItem(
             userRank = rankerList?.getOrNull(0),
             rankerType = FIRST,
-            myUserId = myUserId,
-            navigateToProfile = navigateToProfile,
-            navigateToMyProfile = navigateToMyProfile,
+            onProfileClick = onProfileClick,
             contentWidth = firstWidth,
             sidePadding = sidePadding,
             modifier = Modifier
@@ -91,9 +97,7 @@ fun Ranker(
         RankerItem(
             userRank = rankerList?.getOrNull(1),
             rankerType = SECOND,
-            myUserId = myUserId,
-            navigateToProfile = navigateToProfile,
-            navigateToMyProfile = navigateToMyProfile,
+            onProfileClick = onProfileClick,
             contentWidth = otherWidth,
             sidePadding = sidePadding,
             modifier = Modifier
@@ -102,9 +106,7 @@ fun Ranker(
         RankerItem(
             userRank = rankerList?.getOrNull(2),
             rankerType = THIRD,
-            myUserId = myUserId,
-            navigateToProfile = navigateToProfile,
-            navigateToMyProfile = navigateToMyProfile,
+            onProfileClick = onProfileClick,
             contentWidth = otherWidth,
             sidePadding = sidePadding,
             modifier = Modifier
@@ -119,9 +121,7 @@ private fun RankerItem(
     rankerType: RankerType,
     contentWidth: Dp,
     sidePadding: Dp,
-    myUserId: String?,
-    navigateToProfile: (String) -> Unit,
-    navigateToMyProfile: () -> Unit,
+    onProfileClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val backgroundGradation = Brush.verticalGradient(
@@ -170,13 +170,7 @@ private fun RankerItem(
                         shape = CircleShape,
                     )
                     .noRippleClickable(
-                        onClick = {
-                            if (userRank.userId != myUserId) {
-                                navigateToProfile(userRank.userId)
-                            } else {
-                                navigateToMyProfile()
-                            }
-                        }
+                        onClick = { onProfileClick(userRank.userId) }
                     ),
             )
 
@@ -190,13 +184,7 @@ private fun RankerItem(
                 modifier = Modifier
                     .fillMaxWidth()
                     .noRippleClickable(
-                        onClick = {
-                            if (userRank.userId != myUserId) {
-                                navigateToProfile(userRank.userId)
-                            } else {
-                                navigateToMyProfile()
-                            }
-                        }
+                        onClick = { onProfileClick(userRank.userId) }
                     ),
             )
         }
@@ -291,9 +279,7 @@ private fun RankerItemPreview_FirstPlace() {
         rankerType = FIRST,
         contentWidth = 120.dp,
         sidePadding = 16.dp,
-        navigateToProfile = {},
-        myUserId = "",
-        navigateToMyProfile = {}
+        onProfileClick = {},
     )
 }
 
@@ -312,9 +298,7 @@ private fun RankerItemPreview_SecondPlace() {
         contentWidth = 100.dp,
         sidePadding = 16.dp,
         modifier = Modifier.padding(horizontal = 8.dp),
-        navigateToProfile = {},
-        myUserId = "",
-        navigateToMyProfile = {}
+        onProfileClick = {},
     )
 }
 
@@ -327,9 +311,7 @@ private fun RankerItemPreview_EmptyPlace() {
         contentWidth = 100.dp,
         sidePadding = 16.dp,
         modifier = Modifier.padding(horizontal = 8.dp),
-        navigateToProfile = {},
-        myUserId = "",
-        navigateToMyProfile = {},
+        onProfileClick = {},
     )
 }
 

--- a/app/src/main/java/com/smashing/app/presentation/ranking/component/RankerItem.kt
+++ b/app/src/main/java/com/smashing/app/presentation/ranking/component/RankerItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -160,7 +161,7 @@ private fun RankerItem(
             UrlImage(
                 placeholderDrawable = ProfileImageProvider.getTempImg(userRank.nickname),
                 modifier = Modifier
-                    .height(40.dp)
+                    .size(40.dp)
                     .aspectRatio(1f)
                     .clip(CircleShape)
                     .border(
@@ -239,7 +240,7 @@ private fun RankerItem(
                         painter = painterResource(id = userRank.tier.img()),
                         contentDescription = null,
                         modifier = Modifier
-                            .height(if (rankerType == FIRST) 60.dp else 40.dp)
+                            .size(if (rankerType == FIRST) 60.dp else 40.dp)
                             .aspectRatio(1f),
                     )
 

--- a/app/src/main/java/com/smashing/app/presentation/ranking/component/RankerItem.kt
+++ b/app/src/main/java/com/smashing/app/presentation/ranking/component/RankerItem.kt
@@ -51,6 +51,10 @@ import com.smashing.app.presentation.ranking.type.RankerType.THIRD
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
+private val SIDE_PADDING = 16.dp
+private val RANKER_FIRST_EXTRA_WIDTH = 10.dp
+private const val RANKER_FIRST_WIDTH_RATIO = 0.34f
+private const val RANKER_OTHER_WIDTH_RATIO = 0.33f
 
 @Composable
 fun Ranker(
@@ -64,11 +68,13 @@ fun Ranker(
         modifier = modifier
             .fillMaxWidth()
     ) {
-        val screenWidth = maxWidth
 
-        val sidePadding = screenWidth * 0.04f
-        val firstWidth = screenWidth * 0.342f
-        val otherWidth = screenWidth * 0.29f
+        val sidePadding = SIDE_PADDING
+        val centerExtraWidth = RANKER_FIRST_EXTRA_WIDTH
+
+        val contentAreaWidth = maxWidth - sidePadding * 2 - centerExtraWidth
+        val firstWidth = contentAreaWidth * RANKER_FIRST_WIDTH_RATIO + centerExtraWidth
+        val otherWidth = contentAreaWidth * RANKER_OTHER_WIDTH_RATIO
 
         RankerItem(
             userRank = rankerList?.getOrNull(0),

--- a/app/src/main/java/com/smashing/app/presentation/ranking/component/RankerItem.kt
+++ b/app/src/main/java/com/smashing/app/presentation/ranking/component/RankerItem.kt
@@ -80,7 +80,7 @@ fun Ranker(
         RankerItem(
             userRank = rankerList?.getOrNull(0),
             rankerType = FIRST,
-            myUserId = myUserId ?: "",
+            myUserId = myUserId,
             navigateToProfile = navigateToProfile,
             navigateToMyProfile = navigateToMyProfile,
             contentWidth = firstWidth,
@@ -91,7 +91,7 @@ fun Ranker(
         RankerItem(
             userRank = rankerList?.getOrNull(1),
             rankerType = SECOND,
-            myUserId = myUserId ?: "",
+            myUserId = myUserId,
             navigateToProfile = navigateToProfile,
             navigateToMyProfile = navigateToMyProfile,
             contentWidth = otherWidth,
@@ -102,7 +102,7 @@ fun Ranker(
         RankerItem(
             userRank = rankerList?.getOrNull(2),
             rankerType = THIRD,
-            myUserId = myUserId ?: "",
+            myUserId = myUserId,
             navigateToProfile = navigateToProfile,
             navigateToMyProfile = navigateToMyProfile,
             contentWidth = otherWidth,
@@ -119,7 +119,7 @@ private fun RankerItem(
     rankerType: RankerType,
     contentWidth: Dp,
     sidePadding: Dp,
-    myUserId: String,
+    myUserId: String?,
     navigateToProfile: (String) -> Unit,
     navigateToMyProfile: () -> Unit,
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/smashing/app/presentation/ranking/component/RankerItem.kt
+++ b/app/src/main/java/com/smashing/app/presentation/ranking/component/RankerItem.kt
@@ -56,7 +56,7 @@ import kotlinx.collections.immutable.toImmutableList
 fun Ranker(
     rankerList: ImmutableList<UserRank>?,
     navigateToProfile: (String) -> Unit,
-    myNickname: String?,
+    myUserId: String?,
     navigateToMyProfile: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -73,7 +73,7 @@ fun Ranker(
         RankerItem(
             userRank = rankerList?.getOrNull(0),
             rankerType = FIRST,
-            myNickname = myNickname ?: "",
+            myUserId = myUserId ?: "",
             navigateToProfile = navigateToProfile,
             navigateToMyProfile = navigateToMyProfile,
             contentWidth = firstWidth,
@@ -84,7 +84,7 @@ fun Ranker(
         RankerItem(
             userRank = rankerList?.getOrNull(1),
             rankerType = SECOND,
-            myNickname = myNickname ?: "",
+            myUserId = myUserId ?: "",
             navigateToProfile = navigateToProfile,
             navigateToMyProfile = navigateToMyProfile,
             contentWidth = otherWidth,
@@ -95,7 +95,7 @@ fun Ranker(
         RankerItem(
             userRank = rankerList?.getOrNull(2),
             rankerType = THIRD,
-            myNickname = myNickname ?: "",
+            myUserId = myUserId ?: "",
             navigateToProfile = navigateToProfile,
             navigateToMyProfile = navigateToMyProfile,
             contentWidth = otherWidth,
@@ -112,7 +112,7 @@ private fun RankerItem(
     rankerType: RankerType,
     contentWidth: Dp,
     sidePadding: Dp,
-    myNickname: String,
+    myUserId: String,
     navigateToProfile: (String) -> Unit,
     navigateToMyProfile: () -> Unit,
     modifier: Modifier = Modifier,
@@ -164,7 +164,7 @@ private fun RankerItem(
                     )
                     .noRippleClickable(
                         onClick = {
-                            if (userRank.nickname != myNickname) {
+                            if (userRank.userId != myUserId) {
                                 navigateToProfile(userRank.userId)
                             } else {
                                 navigateToMyProfile()
@@ -184,7 +184,7 @@ private fun RankerItem(
                     .fillMaxWidth()
                     .noRippleClickable(
                         onClick = {
-                            if (userRank.nickname != myNickname) {
+                            if (userRank.userId != myUserId) {
                                 navigateToProfile(userRank.userId)
                             } else {
                                 navigateToMyProfile()
@@ -285,7 +285,7 @@ private fun RankerItemPreview_FirstPlace() {
         contentWidth = 120.dp,
         sidePadding = 16.dp,
         navigateToProfile = {},
-        myNickname = "",
+        myUserId = "",
         navigateToMyProfile = {}
     )
 }
@@ -306,7 +306,7 @@ private fun RankerItemPreview_SecondPlace() {
         sidePadding = 16.dp,
         modifier = Modifier.padding(horizontal = 8.dp),
         navigateToProfile = {},
-        myNickname = "",
+        myUserId = "",
         navigateToMyProfile = {}
     )
 }
@@ -321,7 +321,7 @@ private fun RankerItemPreview_EmptyPlace() {
         sidePadding = 16.dp,
         modifier = Modifier.padding(horizontal = 8.dp),
         navigateToProfile = {},
-        myNickname = "",
+        myUserId = "",
         navigateToMyProfile = {},
     )
 }
@@ -358,7 +358,7 @@ private fun RankerPreview_AllThree() {
                 color = colors.bgCanvas,
             ),
         navigateToProfile = {},
-        myNickname = null,
+        myUserId = null,
         navigateToMyProfile = {},
     )
 }
@@ -384,7 +384,7 @@ private fun RankerPreview_FirstAndSecond() {
             ),
         ).toImmutableList(),
         navigateToProfile = {},
-        myNickname = null,
+        myUserId = null,
         navigateToMyProfile = {},
     )
 }
@@ -395,7 +395,7 @@ private fun RankerPreview_Empty() {
     Ranker(
         rankerList = null,
         navigateToProfile = {},
-        myNickname = null,
+        myUserId = null,
         navigateToMyProfile = {},
     )
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #219 

## Work Description ✏️
- Ranking Screen 파라미터 수정
- userId 로컬에서 가져오기
- 패딩 값 조정

## Screenshot 📸
<img width="264" height="580" alt="image" src="https://github.com/user-attachments/assets/9d5cc16d-b936-4e7c-862e-8722600edac3" />

## Uncompleted Tasks 😅

## To Reviewers 📢
- ci/pr 체커 노션에 추가된 내용 때문인 것 같은데 그 부분은 일어나서 해결할게여.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 랭킹 화면의 프로필 이미지 표시 방식이 개선되었습니다.
  * 랭킹 화면 레이아웃 계산 및 구조가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->