### PR TITLE
[FEAT/#224] R8 progaurd rule 설정 및 agp 버전 update

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,7 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt)
@@ -75,12 +73,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
     }
 
     buildFeatures {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,7 +61,8 @@ android {
 
         release {
             isDebuggable = false
-            isMinifyEnabled = false // TODO: enable in release -isShrinkResources = true
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Kakao SDK model reflection / json parsing safety
+-keep class com.kakao.sdk.**.model.** { <fields>; }
+-dontwarn com.kakao.sdk.**

--- a/app/src/main/java/com/smashing/app/presentation/matching/type/MatchingType.kt
+++ b/app/src/main/java/com/smashing/app/presentation/matching/type/MatchingType.kt
@@ -1,10 +1,12 @@
 package com.smashing.app.presentation.matching.type
 
+import androidx.annotation.Keep
 import androidx.annotation.StringRes
 import com.smashing.app.R.string.matching_confirm
 import com.smashing.app.R.string.matching_receive
 import com.smashing.app.R.string.matching_send
 
+@Keep
 enum class MatchingType(
     @StringRes val labelRes: Int,
 ) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,28 +6,28 @@ versionCode = "1"
 versionName = "1.0.0"
 
 # Build Tools
-agp = "8.13.2"
+agp = "9.0.0"
 
 # AndroidX
 coreKtx = "1.17.0"
-lifecycleRuntimeKtx = "2.9.4"
-datastorePreferences = "1.1.7"
+lifecycleRuntimeKtx = "2.10.0"
+datastorePreferences = "1.2.0"
 androidxAppCompat = "1.7.1"
 
 # Compose
-activityCompose = "1.11.0"
-composeBom = "2025.10.01"
-navigationCompose = "2.9.5"
+activityCompose = "1.12.3"
+composeBom = "2026.01.01"
+navigationCompose = "2.9.7"
 constraintlayoutCompose = "1.1.1"
 
 # Kotlin
-kotlin = "2.2.21"
+kotlin = "2.3.0"
 kotlinxImmutable = "0.4.0"
-kotlinxSerializationJson = "1.9.0"
-kotlinParcelize = "2.2.21"
+kotlinxSerializationJson = "1.10.0"
+kotlinParcelize = "2.3.0"
 
 ## Kotlin Symbol Processing
-ksp = "2.2.21-2.0.4"
+ksp = "2.3.5"
 
 # Test
 junit = "4.13.2"
@@ -35,20 +35,20 @@ junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 
 # Third Party
-lottieCompose = "6.6.6"
+lottieCompose = "6.7.1"
 coil = "3.3.0"
 
 # Network
-okhttp = "5.1.0"
+okhttp = "5.3.2"
 retrofit = "3.0.0"
 retrofitKotlinSerializationConverter = "1.0.0"
 
 # kakao
-kakao = "2.23.1"
+kakao = "2.23.2"
 
 # DI
-hilt = "2.57.1"
-hiltNavigationCompose = "1.2.0"
+hilt = "2.59"
+hiltNavigationCompose = "1.3.0"
 
 # Logging
 timber = "5.0.1"
@@ -106,7 +106,6 @@ timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Dec 24 17:02:19 KST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Related issue 🛠
- closed #224

## Work Description ✏️
- r8 proguard rule 설정
- agp 버전 9.0.0 update
    - agp 버전 업데이트로 내장 kotlin 사용 -> kotlin-android plugin 제거([참고](https://developer.android.com/build/releases/agp-9-0-0-release-notes?hl=ko#android-gradle-plugin-built-in-kotlin))
- 라이브러리 버전 update

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
R8 난독화, 경량화를 적용해보았는데 혹시 release 에서 문제 생기는부분 있으면 말씀해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 빌드 도구 및 라이브러리 종합 업데이트 (Gradle, Android Gradle Plugin, Kotlin 등)
  * 릴리스 빌드에서 코드 최소화 및 리소스 축소 활성화로 앱 성능 및 용량 개선
  * 의존성 업그레이드를 통한 안정성 및 보안 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->