### PR TITLE
[REFACTOR/#242] stringResource 정리

### DIFF
--- a/app/src/main/java/com/smashing/app/core/designsystem/component/card/MatchingCardContent.kt
+++ b/app/src/main/java/com/smashing/app/core/designsystem/component/card/MatchingCardContent.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.dp
 import com.smashing.app.R.string.count
 import com.smashing.app.R.string.record
 import com.smashing.app.R.string.review
-import com.smashing.app.R.string.win_lose_count
+import com.smashing.app.R.string.profile_win_lose_count
 import com.smashing.app.core.designsystem.component.image.UrlImage
 import com.smashing.app.core.designsystem.component.badge.TierBadge
 import com.smashing.app.core.designsystem.mapper.icon20
@@ -88,7 +88,7 @@ private fun RecordSection(
 ) {
     CardDescription(
         prefixText = stringResource(record),
-        suffixText = stringResource(win_lose_count, winCount, loseCount),
+        suffixText = stringResource(profile_win_lose_count, winCount, loseCount),
         modifier = Modifier.padding(top = 8.dp),
     )
 

--- a/app/src/main/java/com/smashing/app/presentation/addsports/AddSportsScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/addsports/AddSportsScreen.kt
@@ -1,5 +1,12 @@
 package com.smashing.app.presentation.addsports
 
+import com.smashing.app.R.string.cancel
+import com.smashing.app.R.string.no
+import com.smashing.app.R.string.addsports_select_sport
+import com.smashing.app.R.string.addsports_select_experience
+import com.smashing.app.R.string.addsports_temporary_tier_determination
+import com.smashing.app.R.string.dialog_cancel_add_item_title
+import com.smashing.app.R.string.dialog_cancel_add_item_message
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -96,11 +103,11 @@ private fun AddSportScreen(
     var showExitDialog by remember { mutableStateOf(false) }
     if (showExitDialog)
         SmashingDialog(
-            title = "종목 추가를 취소하시겠습니까?",
-            subtitle = "취소 시 진행중인 내용은 저장되지 않아요",
+            title = stringResource(dialog_cancel_add_item_title),
+            subtitle = stringResource(dialog_cancel_add_item_message),
             type = DialogStyle.ALERT,
-            confirmText = "취소하기",
-            dismissText = "아니요",
+            confirmText = stringResource(cancel),
+            dismissText = stringResource(no),
             onConfirmClick = {
                 showExitDialog = false
                 onBackClick()
@@ -136,7 +143,7 @@ private fun AddSportScreen(
                     items = uiState.availableSports.toPersistentList(),
                     selectedSport = selectedSport,
                     onSportSelected = onSportSelected,
-                    title = "추가할 종목을 선택해주세요",
+                    title = stringResource(addsports_select_sport),
                     subTitle = "",
                     isSubTitle = false,
                 )
@@ -144,8 +151,8 @@ private fun AddSportScreen(
                 2 -> SportSkillSelector(
                     selectedSkill = selectedSkill,
                     onSkillSelected = onSkillSelected,
-                    title = "구력을 선택해주세요",
-                    subTitle = "구력을 통해 임시 티어가 결정돼요",
+                    title = stringResource(addsports_select_experience),
+                    subTitle = stringResource(addsports_temporary_tier_determination),
                 )
 
                 else -> Spacer(modifier = Modifier.fillMaxSize())

--- a/app/src/main/java/com/smashing/app/presentation/addsports/AddSportsScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/addsports/AddSportsScreen.kt
@@ -7,6 +7,7 @@ import com.smashing.app.R.string.addsports_select_experience
 import com.smashing.app.R.string.addsports_temporary_tier_determination
 import com.smashing.app.R.string.dialog_cancel_add_item_title
 import com.smashing.app.R.string.dialog_cancel_add_item_message
+import com.smashing.app.R.string.addsports_title
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -123,7 +124,7 @@ private fun AddSportScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         SmashingDefaultTopBar(
-            title = "종목 추가",
+            title = stringResource(addsports_title),
             topBarType = TopBarType.CLOSE,
             onClick = { showExitDialog = true },
         )

--- a/app/src/main/java/com/smashing/app/presentation/confirmreview/ConfirmReviewScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/confirmreview/ConfirmReviewScreen.kt
@@ -12,13 +12,17 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.smashing.app.R
 import com.smashing.app.R.drawable.ic_thumbs_down_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_double_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_lg
+import com.smashing.app.R.string.review
+import com.smashing.app.R.string.confirm
 import com.smashing.app.core.designsystem.component.button.SmashingButton
 import com.smashing.app.core.designsystem.component.topbar.SmashingDefaultTopBar
 import com.smashing.app.core.designsystem.style.ButtonStyle
@@ -59,7 +63,7 @@ private fun ConfirmReviewScreen(
             .systemBarsPadding(),
     ) {
         SmashingDefaultTopBar(
-            title = "후기",
+            title = stringResource(review),
             topBarType = TopBarType.DEFAULT,
             onClick = onBackClick,
         )
@@ -72,7 +76,10 @@ private fun ConfirmReviewScreen(
             Spacer(modifier = Modifier.height(24.dp))
 
             Text(
-                text = "${uiState.nickname}님이\n보낸 후기가 도착했어요",
+                text = stringResource(
+                    id = R.string.confirm_review_arrived_with_nickname,
+                    uiState.nickname
+                ),
                 style = SmashingTheme.typography.xl.semibold20,
                 color = SmashingTheme.colors.txtPrimary,
             )
@@ -90,7 +97,7 @@ private fun ConfirmReviewScreen(
 
             SmashingButton(
                 buttonStyle = ButtonStyle.PRIMARY,
-                text = "확인",
+                text = stringResource(confirm),
                 onClick = onConfirmClick,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/smashing/app/presentation/confirmreview/ConfirmReviewScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/confirmreview/ConfirmReviewScreen.kt
@@ -17,12 +17,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.smashing.app.R
 import com.smashing.app.R.drawable.ic_thumbs_down_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_double_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_lg
 import com.smashing.app.R.string.review
 import com.smashing.app.R.string.confirm
+import com.smashing.app.R.string.confirm_review_arrived_with_nickname
 import com.smashing.app.core.designsystem.component.button.SmashingButton
 import com.smashing.app.core.designsystem.component.topbar.SmashingDefaultTopBar
 import com.smashing.app.core.designsystem.style.ButtonStyle
@@ -77,7 +77,7 @@ private fun ConfirmReviewScreen(
 
             Text(
                 text = stringResource(
-                    id = R.string.confirm_review_arrived_with_nickname,
+                    id = confirm_review_arrived_with_nickname,
                     uiState.nickname
                 ),
                 style = SmashingTheme.typography.xl.semibold20,

--- a/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileReviewCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileReviewCard.kt
@@ -27,6 +27,7 @@ import com.smashing.app.R.drawable.ic_thumbs_up_double_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_lg
 import com.smashing.app.R.string.all_review
 import com.smashing.app.R.string.review_receive_review
+import com.smashing.app.R.string.review_no_review_yet
 import com.smashing.app.core.designsystem.component.chip.SmashingChip
 import com.smashing.app.core.designsystem.style.ChipStyle.DISABLED
 import com.smashing.app.core.designsystem.theme.SmashingAndroidTheme
@@ -106,7 +107,7 @@ fun ReviewCard(
 
         if (reviews.isEmpty()) {
             Text(
-                text = "아직 받은 후기가 없어요",
+                text = stringResource(review_no_review_yet),
                 style = SmashingTheme.typography.sm.regular14,
                 color = SmashingTheme.colors.txtPrimary,
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileReviewCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileReviewCard.kt
@@ -26,7 +26,7 @@ import com.smashing.app.R.drawable.ic_thumbs_down_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_double_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_lg
 import com.smashing.app.R.string.all_review
-import com.smashing.app.R.string.receive_review
+import com.smashing.app.R.string.review_receive_review
 import com.smashing.app.core.designsystem.component.chip.SmashingChip
 import com.smashing.app.core.designsystem.style.ChipStyle.DISABLED
 import com.smashing.app.core.designsystem.theme.SmashingAndroidTheme
@@ -60,7 +60,7 @@ fun ReviewCard(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = stringResource(id = receive_review),
+                text = stringResource(id = review_receive_review),
                 style = SmashingTheme.typography.md.semibold16,
                 color = SmashingTheme.colors.txtPrimary,
             )

--- a/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileTierBox.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileTierBox.kt
@@ -28,9 +28,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.smashing.app.R.drawable.ic_fake_red
 import com.smashing.app.R.drawable.ic_plus
-import com.smashing.app.R.string.lp_remaining_text
-import com.smashing.app.R.string.lp_status
-import com.smashing.app.R.string.tier_description
+import com.smashing.app.R.string.profile_lp_remaining_text
+import com.smashing.app.R.string.profile_lp_status
+import com.smashing.app.R.string.profile_tier_description
 import com.smashing.app.core.designsystem.component.badge.TierBadge
 import com.smashing.app.core.designsystem.component.button.SmashingBaseButton
 import com.smashing.app.core.designsystem.component.chip.SmashingChip
@@ -130,13 +130,13 @@ fun ProfileTierBox(
                 )
                 Spacer(modifier = Modifier.width(4.dp))
                 Text(
-                    text = stringResource(lp_remaining_text),
+                    text = stringResource(profile_lp_remaining_text),
                     color = SmashingTheme.colors.txtTertiary,
                     style = SmashingTheme.typography.md.medium16,
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 Text(
-                    text = stringResource(lp_status),
+                    text = stringResource(profile_lp_status),
                     color = SmashingTheme.colors.txtTertiary,
                     style = SmashingTheme.typography.md.medium16,
                 )
@@ -153,7 +153,7 @@ fun ProfileTierBox(
 
                 SmashingBaseButton(
                     modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(tier_description),
+                    text = stringResource(profile_tier_description),
                     textStyle = SmashingTheme.typography.md.semibold16,
                     onClick = onTierInfoClick,
                     buttonColor = SmashingBtnColor(

--- a/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileUserCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileUserCard.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import com.smashing.app.R.string.profile_record_label
 import com.smashing.app.R.string.review
 import com.smashing.app.R.string.apply_competition
+import com.smashing.app.R.string.label_win_lose_record
 import com.smashing.app.core.designsystem.component.image.UrlImage
 import com.smashing.app.core.designsystem.component.badge.TierBadge
 import com.smashing.app.core.designsystem.component.button.SmashingButton
@@ -105,7 +106,7 @@ fun UserProfileCard(
         ) {
             ProfileStatRow(
                 label = stringResource(id = profile_record_label),
-                value = "${winCount}승 ${loseCount}패",
+                value = stringResource(id = label_win_lose_record, winCount, loseCount)
             )
 
             ProfileStatRow(

--- a/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileUserCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileUserCard.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.smashing.app.R.string.profile_record_label
 import com.smashing.app.R.string.review
+import com.smashing.app.R.string.apply_competition
 import com.smashing.app.core.designsystem.component.image.UrlImage
 import com.smashing.app.core.designsystem.component.badge.TierBadge
 import com.smashing.app.core.designsystem.component.button.SmashingButton
@@ -118,7 +119,7 @@ fun UserProfileCard(
 
             SmashingButton(
                 buttonStyle = ButtonStyle.PRIMARY_WITH_DISABLED,
-                text = "경쟁 신청하기",
+                text = stringResource(apply_competition),
                 onClick = onCompeteClick,
                 modifier = Modifier
                     .fillMaxWidth(),

--- a/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileUserCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileUserCard.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.smashing.app.R.string.record_label
+import com.smashing.app.R.string.profile_record_label
 import com.smashing.app.R.string.review
 import com.smashing.app.core.designsystem.component.image.UrlImage
 import com.smashing.app.core.designsystem.component.badge.TierBadge
@@ -103,7 +103,7 @@ fun UserProfileCard(
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             ProfileStatRow(
-                label = stringResource(id = record_label),
+                label = stringResource(id = profile_record_label),
                 value = "${winCount}승 ${loseCount}패",
             )
 

--- a/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileUserCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/component/ProfileUserCard.kt
@@ -25,8 +25,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.smashing.app.R.string.profile_record_label
 import com.smashing.app.R.string.review
-import com.smashing.app.R.string.apply_competition
-import com.smashing.app.R.string.label_win_lose_record
+import com.smashing.app.R.string.profile_apply_competition
+import com.smashing.app.R.string.profile_win_lose_count
 import com.smashing.app.core.designsystem.component.image.UrlImage
 import com.smashing.app.core.designsystem.component.badge.TierBadge
 import com.smashing.app.core.designsystem.component.button.SmashingButton
@@ -106,7 +106,7 @@ fun UserProfileCard(
         ) {
             ProfileStatRow(
                 label = stringResource(id = profile_record_label),
-                value = stringResource(id = label_win_lose_record, winCount, loseCount)
+                value = stringResource(id = profile_win_lose_count, winCount, loseCount)
             )
 
             ProfileStatRow(
@@ -120,7 +120,7 @@ fun UserProfileCard(
 
             SmashingButton(
                 buttonStyle = ButtonStyle.PRIMARY_WITH_DISABLED,
-                text = stringResource(apply_competition),
+                text = stringResource(profile_apply_competition),
                 onClick = onCompeteClick,
                 modifier = Modifier
                     .fillMaxWidth(),

--- a/app/src/main/java/com/smashing/app/presentation/profile/review/AllReviewScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/review/AllReviewScreen.kt
@@ -47,7 +47,7 @@ import com.smashing.app.R.string.review
 import com.smashing.app.R.string.review_satisfaction_review
 import com.smashing.app.R.string.review_no_fast_reviews_yet
 import com.smashing.app.R.string.review_short_review
-import com.smashing.app.R.string.review_no_reviews_yet
+import com.smashing.app.R.string.review_no_review_yet
 import com.smashing.app.core.designsystem.component.chip.SmashingChip
 import com.smashing.app.core.designsystem.component.topbar.SmashingDefaultTopBar
 import com.smashing.app.core.designsystem.style.ChipStyle
@@ -123,7 +123,7 @@ private fun AllReviewScreen(
                 Spacer(Modifier.padding(top = 12.dp))
 
                 Text(
-                    text = stringResource(review_no_reviews_yet),
+                    text = stringResource(review_no_review_yet),
                     style = SmashingTheme.typography.md.medium16,
                     color = SmashingTheme.colors.txtSecondary,
                 )
@@ -260,7 +260,7 @@ private fun AllReviewScreen(
                 } else {
                     item {
                         ReviewEmptyPlaceholder(
-                            text = stringResource(review_no_reviews_yet),
+                            text = stringResource(review_no_review_yet),
                             modifier = Modifier.padding(vertical = 40.dp)
                         )
                     }

--- a/app/src/main/java/com/smashing/app/presentation/profile/review/AllReviewScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/review/AllReviewScreen.kt
@@ -38,14 +38,16 @@ import com.smashing.app.R.drawable.ic_thumbs_down_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_double_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_lg
 import com.smashing.app.R.drawable.img_app_icon
-import com.smashing.app.R.string.fair_play_review
-import com.smashing.app.R.string.fast_response_review
-import com.smashing.app.R.string.good_manner_review
-import com.smashing.app.R.string.on_time_review
-import com.smashing.app.R.string.receive_review
+import com.smashing.app.R.string.chip_fair_play_review
+import com.smashing.app.R.string.chip_fast_response_review
+import com.smashing.app.R.string.chip_good_manner_review
+import com.smashing.app.R.string.chip_on_time_review
+import com.smashing.app.R.string.review_receive_review
 import com.smashing.app.R.string.review
-import com.smashing.app.R.string.satisfaction_review
-import com.smashing.app.R.string.short_review
+import com.smashing.app.R.string.review_satisfaction_review
+import com.smashing.app.R.string.review_no_fast_reviews_yet
+import com.smashing.app.R.string.review_short_review
+import com.smashing.app.R.string.review_no_reviews_yet
 import com.smashing.app.core.designsystem.component.chip.SmashingChip
 import com.smashing.app.core.designsystem.component.topbar.SmashingDefaultTopBar
 import com.smashing.app.core.designsystem.style.ChipStyle
@@ -100,7 +102,7 @@ private fun AllReviewScreen(
     ) {
         SmashingDefaultTopBar(
             modifier = Modifier.statusBarsPadding(),
-            title = stringResource(receive_review),
+            title = stringResource(review_receive_review),
             topBarType = TopBarType.BACK,
             onClick = onBackClick,
         )
@@ -121,7 +123,7 @@ private fun AllReviewScreen(
                 Spacer(Modifier.padding(top = 12.dp))
 
                 Text(
-                    text = "아직 받은 후기가 없어요",
+                    text = stringResource(review_no_reviews_yet),
                     style = SmashingTheme.typography.md.medium16,
                     color = SmashingTheme.colors.txtSecondary,
                 )
@@ -146,7 +148,7 @@ private fun AllReviewScreen(
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Text(
-                            text = stringResource(id = satisfaction_review),
+                            text = stringResource(id = review_satisfaction_review),
                             style = SmashingTheme.typography.md.semibold16,
                             color = SmashingTheme.colors.txtPrimary,
                         )
@@ -184,7 +186,7 @@ private fun AllReviewScreen(
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         Text(
-                            text = stringResource(id = short_review),
+                            text = stringResource(id = review_short_review),
                             style = SmashingTheme.typography.md.semibold16,
                             color = SmashingTheme.colors.txtPrimary,
                         )
@@ -197,32 +199,32 @@ private fun AllReviewScreen(
                             ) {
                                 if (uiState.gameReviewResult.onTimeCount > 0) {
                                     SmashingChip(
-                                        text = "${stringResource(id = on_time_review)} ${uiState.gameReviewResult.onTimeCount}",
+                                        text = "${stringResource(id = chip_on_time_review)} ${uiState.gameReviewResult.onTimeCount}",
                                         style = ChipStyle.DISABLED,
                                     )
                                 }
                                 if (uiState.gameReviewResult.goodMannerCount > 0) {
                                     SmashingChip(
-                                        text = "${stringResource(id = good_manner_review)} ${uiState.gameReviewResult.goodMannerCount}",
+                                        text = "${stringResource(id = chip_good_manner_review)} ${uiState.gameReviewResult.goodMannerCount}",
                                         style = ChipStyle.DISABLED,
                                     )
                                 }
                                 if (uiState.gameReviewResult.fairPlayCount > 0) {
                                     SmashingChip(
-                                        text = "${stringResource(id = fair_play_review)} ${uiState.gameReviewResult.fairPlayCount}",
+                                        text = "${stringResource(id = chip_fair_play_review)} ${uiState.gameReviewResult.fairPlayCount}",
                                         style = ChipStyle.DISABLED,
                                     )
                                 }
                                 if (uiState.gameReviewResult.fastResponseCount > 0) {
                                     SmashingChip(
-                                        text = "${stringResource(id = fast_response_review)} ${uiState.gameReviewResult.fastResponseCount}",
+                                        text = "${stringResource(id = chip_fast_response_review)} ${uiState.gameReviewResult.fastResponseCount}",
                                         style = ChipStyle.DISABLED,
                                     )
                                 }
                             }
                         } else {
                             ReviewEmptyPlaceholder(
-                                text = "아직 받은 빠른 후기가 없어요",
+                                text = stringResource(id = review_no_fast_reviews_yet),
                                 modifier = Modifier.padding(vertical = 20.dp)
                             )
                         }
@@ -258,7 +260,7 @@ private fun AllReviewScreen(
                 } else {
                     item {
                         ReviewEmptyPlaceholder(
-                            text = "아직 받은 후기가 없어요",
+                            text = stringResource(review_no_reviews_yet),
                             modifier = Modifier.padding(vertical = 40.dp)
                         )
                     }

--- a/app/src/main/java/com/smashing/app/presentation/profile/review/AllReviewScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/review/AllReviewScreen.kt
@@ -47,6 +47,7 @@ import com.smashing.app.R.string.review
 import com.smashing.app.R.string.review_satisfaction_review
 import com.smashing.app.R.string.review_no_fast_reviews_yet
 import com.smashing.app.R.string.review_short_review
+import com.smashing.app.R.string.review_with_count
 import com.smashing.app.R.string.review_no_review_yet
 import com.smashing.app.core.designsystem.component.chip.SmashingChip
 import com.smashing.app.core.designsystem.component.topbar.SmashingDefaultTopBar
@@ -199,7 +200,11 @@ private fun AllReviewScreen(
                             ) {
                                 if (uiState.gameReviewResult.onTimeCount > 0) {
                                     SmashingChip(
-                                        text = "${stringResource(id = chip_on_time_review)} ${uiState.gameReviewResult.onTimeCount}",
+                                        text = stringResource(
+                                            id = review_with_count,
+                                            stringResource(id = chip_on_time_review),
+                                            uiState.gameReviewResult.onTimeCount
+                                        ),
                                         style = ChipStyle.DISABLED,
                                     )
                                 }

--- a/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileScreen.kt
@@ -32,6 +32,12 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.smashing.app.R.string.profile
+import com.smashing.app.R.string.profile_competition_applied
+import com.smashing.app.R.string.profile_check_matching_tab
+import com.smashing.app.R.string.profile_go_to_link
+import com.smashing.app.R.string.accept
+import com.smashing.app.R.string.skip
+import com.smashing.app.R.string.confirm
 import com.smashing.app.core.designsystem.component.button.SmashingButton
 import com.smashing.app.core.designsystem.component.dialog.SmashingDialog
 import com.smashing.app.core.designsystem.component.toast.LocalToastTrigger
@@ -148,17 +154,16 @@ private fun UserProfileScreen(
                 if (uiState.isDialogVisible) {
 
                     SmashingDialog(
-                        title = "경쟁 신청이 완료되었습니다!",
-                        subtitle = "매칭 관리 탭에서 매칭 정보를 확인해주세요.",
+                        title = stringResource(profile_competition_applied),
+                        subtitle = stringResource(profile_check_matching_tab),
                         type = DialogStyle.ALERT,
-                        confirmText = "바로가기",
-                        dismissText = "확인",
+                        confirmText = stringResource(profile_go_to_link),
+                        dismissText = stringResource(confirm),
                         onConfirmClick = onConfirmClick,
                         onDismissClick = onDialogDismissClick,
                         onDismissRequest = onDialogDismissClick,
                     )
                 }
-
 
                 ProfileTierBox(
                     tierType = uiState.activeProfile.tierType,
@@ -209,13 +214,13 @@ private fun UserProfileScreen(
                     ) {
                         SmashingButton(
                             buttonStyle = ButtonStyle.DISABLED_ACTIVE,
-                            text = "건너뛰기",
+                            text = stringResource(skip),
                             modifier = Modifier.weight(BTN_WEIGHT),
                             onClick = onNoClick,
                         )
                         SmashingButton(
                             buttonStyle = ButtonStyle.PRIMARY,
-                            text = "수락",
+                            text = stringResource(accept),
                             modifier = Modifier.weight(1f),
                             onClick = onYesClick,
                         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,14 +13,10 @@
     <string name="zero_label">0</string>
     <string name="blank_label"></string>
     <string name="score_separator">:</string>
-
-    <!-- Login -->
-    <string name="kakao_login">카카오로 시작하기</string>
-    <string name="login_description_s">스</string>
-    <string name="login_description_for_ports">포츠인들을 위한&#160;</string>
-    <string name="login_description_m">매</string>
-    <string name="login_description_athching">칭서비스는&#160;</string>
-    <string name="login_description_ing">계속된다</string>
+    <string name="confirm">확인</string>
+    <string name="win_label">승리</string>
+    <string name="lose_label">패배</string>
+    <string name="rate_label">승률</string>
 
     <!--Ranking -->
     <string name="ranking_tier_with_lp">%1$s · %2$d LP</string>
@@ -33,38 +29,22 @@
     <string name="kakao_link">카카오톡 링크</string>
     <string name="win_lose_count">%1$d승 %2$d패</string>
 
+    <!--Dialog -->
+    <string name="dialog_cancel_add_item_title">종목 추가를 취소하시겠습니까?</string>
+    <string name="dialog_cancel_add_item_message">취소 시 진행중인 내용은 저장되지 않아요</string>
+
+    <!--Chip-->
+    <string name="chip_on_time_review">시간 약속을 잘 지켜요</string>
+    <string name="chip_good_manner_review">경기 매너가 좋아요</string>
+    <string name="chip_fair_play_review">승패를 깔끔하게 인정해요</string>
+    <string name="chip_fast_response_review">응답이 빨라요</string>
+
     <!--Progress -->
     <string name="progress_label">progress</string>
 
     <!--Dropdown -->
     <string name="dropdown_region_select">내 지역 변경</string>
     <string name="dropdown_winner_select">승자 선택</string>
-    <!--SignUp  -->
-    <string name="sign_up_next_btn">다음</string>
-    <string name="sign_up_end_btn">완료</string>
-    <string name="sign_up_nickname_title">닉네임을 입력해주세요</string>
-    <string name="sign_up_nickname_subtitle">한글, 영어, 숫자만 가능해요</string>
-    <string name="sign_up_nickname_duplicate">중복확인</string>
-    <string name="sign_up_gender_title">성별을 선택해주세요</string>
-    <string name="sign_up_chat_link_title">카카오톡 오픈채팅 링크를 입력해주세요</string>
-    <string name="sign_up_chat_link_subtitle">매칭이 확정되면 상대방이 확인할 수 있어요</string>
-    <string name="sign_up_chat_link_placeholder">오픈채팅 링크를 입력해주세요</string>
-    <string name="sign_up_sport_title">종목을 선택해주세요</string>
-    <string name="sign_up_sport_subtitle">회원가입 이후 종목을 추가할 수 있어요</string>
-    <string name="sign_up_skill_title">구력을 선택해주세요</string>
-    <string name="sign_up_skill_subtitle">구력을 통해 임시 티어가 결정돼요</string>
-    <string name="sign_up_location_title">활동 지역을 설정해주세요</string>
-    <string name="sign_up_location_subtitle">서울 소재 주소만 입력 가능해요</string>
-    <string name="sign_up_location_placeholder">주소를 검색해주세요</string>
-    <string name="sign_up_finish_title">환영합니다!</string>
-    <string name="sign_up_finish_subtitle">스매싱과 함께 동네 최강이 되어봐요!</string>
-
-    <!--Home  -->
-    <string name="home_no_matching">아직 확정된 매칭이 없어요.\n지금 바로 매칭을 신청해보세요!</string>
-    <string name="home_all_text">모두 보기</string>
-    <string name="home_region_ranker">우리 동네 랭커</string>
-    <string name="home_no_user">아직 동네 유저가 없어요</string>
-    <string name="home_clos_matching_txt">곧 다가오는 매칭이 있어요</string>
 
 
     <!-- ========== Badminton Tier Info ========== -->
@@ -292,6 +272,43 @@
     <string name="tier_challenger_name">결국 해내셨군요!</string>
     <string name="tier_challenger_description">끊임없이 덤비는 도전자들로부터 자격을 증명하세요!</string>
 
+    <!-- ==========Presentation ========== -->
+
+    <!-- Login -->
+    <string name="kakao_login">카카오로 시작하기</string>
+    <string name="login_description_s">스</string>
+    <string name="login_description_for_ports">포츠인들을 위한&#160;</string>
+    <string name="login_description_m">매</string>
+    <string name="login_description_athching">칭서비스는&#160;</string>
+    <string name="login_description_ing">계속된다</string>
+
+
+    <!--SignUp  -->
+    <string name="sign_up_next_btn">다음</string>
+    <string name="sign_up_end_btn">완료</string>
+    <string name="sign_up_nickname_title">닉네임을 입력해주세요</string>
+    <string name="sign_up_nickname_subtitle">한글, 영어, 숫자만 가능해요</string>
+    <string name="sign_up_nickname_duplicate">중복확인</string>
+    <string name="sign_up_gender_title">성별을 선택해주세요</string>
+    <string name="sign_up_chat_link_title">카카오톡 오픈채팅 링크를 입력해주세요</string>
+    <string name="sign_up_chat_link_subtitle">매칭이 확정되면 상대방이 확인할 수 있어요</string>
+    <string name="sign_up_chat_link_placeholder">오픈채팅 링크를 입력해주세요</string>
+    <string name="sign_up_sport_title">종목을 선택해주세요</string>
+    <string name="sign_up_sport_subtitle">회원가입 이후 종목을 추가할 수 있어요</string>
+    <string name="sign_up_skill_title">구력을 선택해주세요</string>
+    <string name="sign_up_skill_subtitle">구력을 통해 임시 티어가 결정돼요</string>
+    <string name="sign_up_location_title">활동 지역을 설정해주세요</string>
+    <string name="sign_up_location_subtitle">서울 소재 주소만 입력 가능해요</string>
+    <string name="sign_up_location_placeholder">주소를 검색해주세요</string>
+    <string name="sign_up_finish_title">환영합니다!</string>
+    <string name="sign_up_finish_subtitle">스매싱과 함께 동네 최강이 되어봐요!</string>
+
+    <!--Home  -->
+    <string name="home_no_matching">아직 확정된 매칭이 없어요.\n지금 바로 매칭을 신청해보세요!</string>
+    <string name="home_all_text">모두 보기</string>
+    <string name="home_region_ranker">우리 동네 랭커</string>
+    <string name="home_no_user">아직 동네 유저가 없어요</string>
+    <string name="home_clos_matching_txt">곧 다가오는 매칭이 있어요</string>
 
     <!--Matching -->
     <string name="matching_btn_write">결과 작성하기</string>
@@ -311,39 +328,52 @@
     <string name="matching_send_dialog_description">요청 취소 시 24시간 후 재요청할 수 있습니다.</string>
     <string name="matching_accepted_dialog_title">정말 매칭을 취소하시겠습니까?</string>
     <string name="matching_accepted_dialog_description">매칭 상대도 동의해야 취소가 완료됩니다.</string>
+
     <!--Search  -->
     <string name="search_placeholder">닉네임을 검색해주세요</string>
-    <!--Profile -->
+
     <!--Notice  -->
     <string name="notice">알림</string>
+
     <!--Profile-->
-    <string name="win_label">승리</string>
-    <string name="lose_label">패배</string>
-    <string name="rate_label">승률</string>
-    <string name="add_sports_label">+</string>
-    <string name="tier_description">티어 설명</string>
-    <string name="lp_remaining_text">LP 남았어요!</string>
-    <string name="lp_status">LP</string>
-    <string name="record_label">전적</string>
-    <string name="receive_review">받은 후기</string>
-    <string name="short_review">빠른 후기</string>
+    <string name="profile_add_sports_label">+</string>
+    <string name="profile_tier_description">티어 설명</string>
+    <string name="profile_lp_remaining_text">LP 남았어요!</string>
+    <string name="profile_lp_status">LP</string>
+    <string name="profile_record_label">전적</string>
     <string name="all_review">모두 보기</string>
-    <string name="on_time_review">시간 약속을 잘 지켜요</string>
-    <string name="good_manner_review">경기 매너가 좋아요</string>
-    <string name="fair_play_review">승패를 깔끔하게 인정해요</string>
-    <string name="fast_response_review">응답이 빨라요</string>
-    <string name="satisfaction_review">만족도</string>
     <string name="profile_rate_percent">%d%%</string>
+    <string name="profile_competition_applied">경쟁 신청이 완료되었습니다!</string>
+    <string name="profile_check_matching_tab">매칭 관리 탭에서 매칭 정보를 확인해주세요.</string>
+    <string name="profile_go_to_link">바로가기</string>
+
+    <!--AllReveiw-->
+    <string name="review_receive_review">받은 후기</string>
+    <string name="review_no_reviews_yet">아직 받은 후기가 없어요</string>
+    <string name="review_no_fast_reviews_yet">아직 받은 빠른 후기가 없어요</string>
+    <string name="review_short_review">빠른 후기</string>
+    <string name="review_satisfaction_review">만족도</string>
+
+    <!--ConfrimReveiw-->
+    <string name="confirm_review_arrived_with_nickname">%1$s님이\n보낸 후기가 도착했어요</string>
+
+
+    <!--AddSports-->
+    <string name="addsports_select_sport">추가할 종목을 선택해주세요</string>
+    <string name="addsports_select_experience">구력을 선택해주세요</string>
+    <string name="addsports_temporary_tier_determination">구력을 통해 임시 티어가 결정돼요</string>
+
+
     <!--Submit  -->
     <string name="submit_matching_result">결과 작성</string>
     <string name="submit_title">경기 결과를 작성해주세요</string>
     <string name="submit_description">악의적인 결과 작성 시 활동이 제한될 수 있어요</string>
     <string name="submit_winner">승자</string>
     <string name="submit_score">스코어</string>
+
     <!--Confirm  -->
     <string name="confirm_result">결과 확인</string>
     <string name="confirm_result_title">경기 결과를 확인해주세요</string>
-
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="kakao_link">카카오톡 링크</string>
     <string name="win_lose_count">%1$d승 %2$d패</string>
     <string name="apply_competition">경쟁 신청하기</string>
+    <string name="label_win_lose_record">%1$d승 %2$d패</string>
+
 
     <!--Dialog -->
     <string name="dialog_cancel_add_item_title">종목 추가를 취소하시겠습니까?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -356,6 +356,7 @@
     <string name="review_no_fast_reviews_yet">아직 받은 빠른 후기가 없어요</string>
     <string name="review_short_review">빠른 후기</string>
     <string name="review_satisfaction_review">만족도</string>
+    <string name="review_with_count">%1$s %2$d</string>
 
     <!--ConfrimReveiw-->
     <string name="confirm_review_arrived_with_nickname">%1$s님이\n보낸 후기가 도착했어요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="skip">건너뛰기</string>
     <string name="kakao_link">카카오톡 링크</string>
     <string name="win_lose_count">%1$d승 %2$d패</string>
+    <string name="apply_competition">경쟁 신청하기</string>
 
     <!--Dialog -->
     <string name="dialog_cancel_add_item_title">종목 추가를 취소하시겠습니까?</string>
@@ -349,7 +350,7 @@
 
     <!--AllReveiw-->
     <string name="review_receive_review">받은 후기</string>
-    <string name="review_no_reviews_yet">아직 받은 후기가 없어요</string>
+    <string name="review_no_review_yet">아직 받은 후기가 없어요</string>
     <string name="review_no_fast_reviews_yet">아직 받은 빠른 후기가 없어요</string>
     <string name="review_short_review">빠른 후기</string>
     <string name="review_satisfaction_review">만족도</string>
@@ -362,7 +363,7 @@
     <string name="addsports_select_sport">추가할 종목을 선택해주세요</string>
     <string name="addsports_select_experience">구력을 선택해주세요</string>
     <string name="addsports_temporary_tier_determination">구력을 통해 임시 티어가 결정돼요</string>
-
+    <string name="addsports_title">종목 추가</string>
 
     <!--Submit  -->
     <string name="submit_matching_result">결과 작성</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,10 +27,6 @@
     <string name="accept">수락</string>
     <string name="skip">건너뛰기</string>
     <string name="kakao_link">카카오톡 링크</string>
-    <string name="win_lose_count">%1$d승 %2$d패</string>
-    <string name="apply_competition">경쟁 신청하기</string>
-    <string name="label_win_lose_record">%1$d승 %2$d패</string>
-
 
     <!--Dialog -->
     <string name="dialog_cancel_add_item_title">종목 추가를 취소하시겠습니까?</string>
@@ -349,6 +345,9 @@
     <string name="profile_competition_applied">경쟁 신청이 완료되었습니다!</string>
     <string name="profile_check_matching_tab">매칭 관리 탭에서 매칭 정보를 확인해주세요.</string>
     <string name="profile_go_to_link">바로가기</string>
+    <string name="profile_win_lose_count">%1$d승 %2$d패</string>
+    <string name="profile_apply_competition">경쟁 신청하기</string>
+
 
     <!--AllReveiw-->
     <string name="review_receive_review">받은 후기</string>


### PR DESCRIPTION
## Related issue 🛠
- closed #242

## Work Description ✏️
-  기존 혼용되어있던 상황을 모두 stringResource 로 분리했습니다. 
작업한 뷰
- UserProfile/MyProfile
- ConfirmReview
- AddSports
- AllReview

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
네이밍의 경우 다른 것들이랑 통일시키려고했는데 이렇게 하는게 맞는지 확인 부탁드립니다이 (presentation 앞에 해당 뷰 이름 붙임ex.profile_tier_description)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 하드코딩된 UI 텍스트를 문자열 리소스로 통합하여 로컬라이제이션 체계를 개선했습니다.
  * 문자열 리소스를 기능별로 재구성했습니다(프로필, 리뷰, 스포츠 추가, 확인 등).
  * 스포츠 선택, 리뷰 관리, 사용자 프로필 등 여러 화면의 UI 텍스트를 리소스 기반으로 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->