### PR TITLE
[Fix/#251] hiltViewModel 패키지 변경

### DIFF
--- a/app/src/main/java/com/smashing/app/core/extension/NavBackStackEntryExt.kt
+++ b/app/src/main/java/com/smashing/app/core/extension/NavBackStackEntryExt.kt
@@ -2,7 +2,7 @@ package com.smashing.app.core.extension
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController

--- a/app/src/main/java/com/smashing/app/presentation/addsports/AddSportsScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/addsports/AddSportsScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle

--- a/app/src/main/java/com/smashing/app/presentation/confirmreview/ConfirmReviewScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/confirmreview/ConfirmReviewScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.smashing.app.R.drawable.ic_thumbs_down_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_double_lg

--- a/app/src/main/java/com/smashing/app/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/HomeScreen.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner

--- a/app/src/main/java/com/smashing/app/presentation/home/regionchange/RegionChangeScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/home/regionchange/RegionChangeScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle

--- a/app/src/main/java/com/smashing/app/presentation/login/LoginScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/login/LoginScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.flowWithLifecycle
 import com.smashing.app.R

--- a/app/src/main/java/com/smashing/app/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/main/MainScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle

--- a/app/src/main/java/com/smashing/app/presentation/matching/MatchingScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/matching/MatchingScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner

--- a/app/src/main/java/com/smashing/app/presentation/notice/NoticeScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/notice/NoticeScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle

--- a/app/src/main/java/com/smashing/app/presentation/profile/myprofile/MyProfileScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/myprofile/MyProfileScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.smashing.app.R.string.profile
 import com.smashing.app.core.designsystem.component.topbar.SmashingDefaultTopBar

--- a/app/src/main/java/com/smashing/app/presentation/profile/review/AllReviewScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/review/AllReviewScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.smashing.app.R.drawable.ic_thumbs_down_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_double_lg

--- a/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle

--- a/app/src/main/java/com/smashing/app/presentation/ranking/RankingScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/ranking/RankingScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.smashing.app.R.string.ranking_tier_with_lp
 import com.smashing.app.core.designsystem.component.image.UrlImage

--- a/app/src/main/java/com/smashing/app/presentation/region/RegionScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/region/RegionScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle

--- a/app/src/main/java/com/smashing/app/presentation/search/input/SearchInputScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/search/input/SearchInputScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.smashing.app.R.string.search_placeholder
 import com.smashing.app.core.designsystem.component.topbar.SmashingSearchTopBar

--- a/app/src/main/java/com/smashing/app/presentation/search/searchmain/SearchMainScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/search/searchmain/SearchMainScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.smashing.app.core.designsystem.component.bottomsheet.SmashingBottomSheet
 import com.smashing.app.core.designsystem.component.card.MatchingCard

--- a/app/src/main/java/com/smashing/app/presentation/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/signup/SignUpScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle

--- a/app/src/main/java/com/smashing/app/presentation/tierinfo/TierInfoScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/tierinfo/TierInfoScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.smashing.app.core.designsystem.component.appicon.AppIcon
 import com.smashing.app.core.designsystem.component.chip.SmashingChip

--- a/app/src/main/java/com/smashing/app/presentation/write/confirm/ConfirmReviewScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/confirm/ConfirmReviewScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ kakao = "2.23.2"
 
 # DI
 hilt = "2.59"
-hiltNavigationCompose = "1.3.0"
+hiltCompose = "1.3.0"
 
 # Logging
 timber = "5.0.1"
@@ -99,8 +99,8 @@ kakao-sdk-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kak
 # DI
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
-hilt-lifecycle-viewmodel-compose = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "hiltNavigationCompose" }
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltCompose" }
+hilt-lifecycle-viewmodel-compose = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "hiltCompose" }
 
 # Logging
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,6 +100,7 @@ kakao-sdk-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kak
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+hilt-lifecycle-viewmodel-compose = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "hiltNavigationCompose" }
 
 # Logging
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
@@ -139,6 +140,7 @@ network = [
 hilt = [
     "hilt-android",
     "hilt-navigation-compose",
+    "hilt-lifecycle-viewmodel-compose",
 ]
 
 debug = [


### PR DESCRIPTION
## Related issue 🛠
- closed #251 

## Work Description ✏️
- 현재 hiltViewModel()을 사용하는 부분이 deprecated 상태로 되어 있습니다.
- 기존 navigation 패키지에 있던 hiltViewModel이 의존성이 분리되어 androidx.hilt.lifecycle.viewmodel.compose로 이동하게 되어 해당 부분 수정했습니다.

## Screenshot 📸

## Uncompleted Tasks 😅
- [ ] Task1

## To Reviewers 📢
- 코드 짜다가 계속 deprecated 상태가 보여서 일단 수정해두었는데, 별로면 머지 안하고 날려도 괜찮아여
- 혹시 더 수정해야하는 부분이나 수정하면 안되는 부분 있으면 코멘트 남겨주세요!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- 앱의 여러 화면에서 사용되는 의존성 라이브러리 참조를 최신 버전으로 업데이트했습니다.
- 프로젝트 전체 라이브러리 구성을 개선하여 앱의 코드 안정성과 장기적인 유지보수성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->