### PR TITLE
[CHORE/#261] MyPage 링크 수정 및 버전 정보 클릭 이벤트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,5 @@ hs_err_pid*
 .firebase/
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,android,windows,intellij,androidstudio
+fastlane/key/app-distribution-key.json
+fastlane/key/play-console-key.json

--- a/.gitignore
+++ b/.gitignore
@@ -364,5 +364,4 @@ hs_err_pid*
 .firebase/
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,android,windows,intellij,androidstudio
-fastlane/key/app-distribution-key.json
-fastlane/key/play-console-key.json
+

--- a/app/src/main/java/com/smashing/app/presentation/mypage/MypageScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/mypage/MypageScreen.kt
@@ -94,6 +94,7 @@ fun MyPageRoute(
         onWithDrawClick = navigateToWithDraw,
         onPolicyPrivacyClick = { policyPrivacyLink -> context.openUrl(policyPrivacyLink) },
         onPolicyTermsClick = { kakaoLink -> context.openUrl(kakaoLink) },
+        onVersionClick = { versionLink -> context.openUrl(versionLink) },
         onBackClick = navigateUp,
     )
 }
@@ -109,6 +110,7 @@ private fun MyPageScreen(
     modifier: Modifier = Modifier,
     onPolicyPrivacyClick: (String?) -> Unit = {},
     onPolicyTermsClick: (String?) -> Unit = {},
+    onVersionClick: (String?) -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
     Column(
@@ -204,6 +206,8 @@ private fun MyPageScreen(
                     text = stringResource(mypage_info_version),
                     style = typography.sm.medium14,
                     color = colors.txtPrimary,
+                    modifier = Modifier
+                        .noRippleClickable(onClick = { onVersionClick(versionLink) })
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 Text(
@@ -216,8 +220,12 @@ private fun MyPageScreen(
     }
 }
 
-private const val policyPrivacyLink = "https://github.com/TEAM-SMASHING/SMASHING-ANDROID"
-private const val policyTermsLink = "https://github.com/TEAM-SMASHING/SMASHING-ANDROID"
+private const val policyPrivacyLink =
+    "https://elated-piccolo-63b.notion.site/30b4556d60d18092b22ad0e23a84eee2?pvs=143"
+private const val policyTermsLink =
+    "https://elated-piccolo-63b.notion.site/30b4556d60d18015a556ed889292a6e4?pvs=143"
+private const val versionLink =
+    "https://elated-piccolo-63b.notion.site/30b4556d60d18010bb2aff85c555cd9e?pvs=143"
 
 
 @Preview(showBackground = true)


### PR DESCRIPTION
## Related issue 🛠
- closed #261 

## Work Description ✏️
- MyPage 링크 수정 및 버전 정보 클릭 이벤트 추가했습니다!

## Screenshot 📸
<img src="" width="360"/>

https://github.com/user-attachments/assets/4ce4b9bf-5011-43e0-9e14-1c770d0216ad

연결이 좀 느려요 ㅎㅎ;;😅


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
감사띵


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마이페이지의 버전 항목을 클릭 가능하도록 변경했습니다.

* **업데이트**
  * 정책 및 약관 링크를 새로운 페이지로 변경했습니다.

* **기타**
  * 빌드 무시 파일 목록을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->