### PR TITLE
[UI/#265] 결과 작성, 확인하기 점수 입력 필드 제거

### DIFF
--- a/app/src/main/java/com/smashing/app/data/mapper/game/PostGameSubmissionMapper.kt
+++ b/app/src/main/java/com/smashing/app/data/mapper/game/PostGameSubmissionMapper.kt
@@ -7,8 +7,6 @@ fun GameSubmission.toRequest(): PostGameSubmissionRequest {
     return PostGameSubmissionRequest(
         winnerUserId = winnerUserId,
         loserUserId = loserUserId,
-        winnerScore = winnerScore,
-        loserScore = loserScore,
         review = review?.toDto(),
     )
 }
@@ -20,4 +18,3 @@ private fun GameSubmission.Review.toDto(): PostGameSubmissionRequest.Review {
         tags = tags,
     )
 }
-

--- a/app/src/main/java/com/smashing/app/data/model/game/GameSubmission.kt
+++ b/app/src/main/java/com/smashing/app/data/model/game/GameSubmission.kt
@@ -3,8 +3,6 @@ package com.smashing.app.data.model.game
 data class GameSubmission(
     val winnerUserId: String,
     val loserUserId: String,
-    val winnerScore: Int,
-    val loserScore: Int,
     val review: Review?,
 ) {
     data class Review(

--- a/app/src/main/java/com/smashing/app/data/remote/dto/game/PostGameSubmissionRequest.kt
+++ b/app/src/main/java/com/smashing/app/data/remote/dto/game/PostGameSubmissionRequest.kt
@@ -9,10 +9,6 @@ data class PostGameSubmissionRequest(
     val winnerUserId: String,
     @SerialName("loserUserId")
     val loserUserId: String,
-    @SerialName("scoreWinner")
-    val winnerScore: Int,
-    @SerialName("scoreLoser")
-    val loserScore: Int,
     @SerialName("review")
     val review: Review?,
 ) {

--- a/app/src/main/java/com/smashing/app/presentation/write/component/SubmitCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/component/SubmitCard.kt
@@ -62,8 +62,8 @@ fun SubmitCard(
             modifier = Modifier
                 .align(Alignment.Center)
                 .padding(
-                    top = 59.dp,
-                    bottom = 58.dp,
+                    top = 50.dp,
+                    bottom = 68.dp,
                 ),
         )
 

--- a/app/src/main/java/com/smashing/app/presentation/write/component/SubmitCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/component/SubmitCard.kt
@@ -32,7 +32,7 @@ import com.smashing.app.core.util.ProfileImageProvider
 import com.smashing.app.presentation.write.model.PlayerInfo
 
 @Composable
-fun SubmitScoreCard(
+fun SubmitCard(
     leftUser: PlayerInfo,
     rightUser: PlayerInfo,
     modifier: Modifier = Modifier,
@@ -128,9 +128,9 @@ private fun ProfileInfo(
 
 @Preview(showBackground = true)
 @Composable
-private fun ProfileInfoPreview() {
+private fun SubmitCardPreview() {
     SmashingAndroidTheme {
-        SubmitScoreCard(
+        SubmitCard(
             leftUser = PlayerInfo(userId = "1", name = "하나둘"),
             rightUser = PlayerInfo(userId = "2", name = "하나둘셋넷다여일여아열"),
             winnerId = "1",

--- a/app/src/main/java/com/smashing/app/presentation/write/component/SubmitScoreCard.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/component/SubmitScoreCard.kt
@@ -21,12 +21,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.smashing.app.R.drawable.ic_crown
-import com.smashing.app.R.string.score_format
 import com.smashing.app.core.designsystem.component.image.UrlImage
 import com.smashing.app.core.designsystem.theme.SmashingAndroidTheme
 import com.smashing.app.core.designsystem.theme.SmashingTheme
@@ -58,18 +56,14 @@ fun SubmitScoreCard(
         )
 
         Text(
-            text = stringResource(
-                score_format,
-                leftUser.score,
-                rightUser.score
-            ),
+            text = "vs",
             color = SmashingTheme.colors.txtSecondary,
             style = SmashingTheme.typography.hero.semibold28,
             modifier = Modifier
                 .align(Alignment.Center)
                 .padding(
-                    top = 50.dp,
-                    bottom = 68.dp,
+                    top = 59.dp,
+                    bottom = 58.dp,
                 ),
         )
 
@@ -137,8 +131,8 @@ private fun ProfileInfo(
 private fun ProfileInfoPreview() {
     SmashingAndroidTheme {
         SubmitScoreCard(
-            leftUser = PlayerInfo(userId = "1", name = "하나둘", score = 0),
-            rightUser = PlayerInfo(userId = "2", name = "하나둘셋넷다여일여아열", score = 0),
+            leftUser = PlayerInfo(userId = "1", name = "하나둘"),
+            rightUser = PlayerInfo(userId = "2", name = "하나둘셋넷다여일여아열"),
             winnerId = "1",
         )
     }

--- a/app/src/main/java/com/smashing/app/presentation/write/component/WriteResultContent.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/component/WriteResultContent.kt
@@ -1,33 +1,28 @@
 package com.smashing.app.presentation.write.component
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
 import com.smashing.app.R.string.asterisk_label
-import com.smashing.app.R.string.score_separator
-import com.smashing.app.R.string.submit_score
 import com.smashing.app.R.string.submit_title
 import com.smashing.app.R.string.submit_winner
-import com.smashing.app.R.string.zero_label
 import com.smashing.app.core.designsystem.component.dropdown.SmashingWinnerDropdown
-import com.smashing.app.core.designsystem.component.textfield.ScoreInputTextField
 import com.smashing.app.core.designsystem.theme.SmashingAndroidTheme
 import com.smashing.app.core.designsystem.theme.SmashingTheme
-import com.smashing.app.core.extension.intValue
 import com.smashing.app.presentation.write.model.PlayerInfo
 import kotlinx.collections.immutable.persistentListOf
 
@@ -36,20 +31,22 @@ fun WriteResultContent(
     leftUserInfo: PlayerInfo,
     rightUserInfo: PlayerInfo,
     winnerId: String?,
-    leftTextFieldState: TextFieldState,
-    rightTextFieldState: TextFieldState,
     modifier: Modifier = Modifier,
-    isTextFieldsEnabled: Boolean = true,
+    isContentEnabled: Boolean = true,
     title: String = stringResource(submit_title),
     subTitle: String? = null,
     onWinnerSelected: (String) -> Unit = {},
-    onLeftDoneClick: (Int) -> Unit = {},
-    onRightDoneClick: (Int) -> Unit = {},
 ) {
     val dropDownList = persistentListOf(
         leftUserInfo.name,
         rightUserInfo.name,
     )
+
+    val winnerName = when (winnerId) {
+        rightUserInfo.userId -> rightUserInfo.name
+        leftUserInfo.userId -> leftUserInfo.name
+        else -> null
+    }
 
     Column(
         modifier = modifier
@@ -76,90 +73,22 @@ fun WriteResultContent(
             modifier = Modifier.padding(top = 28.dp),
         )
 
-        ConstraintLayout(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 20.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            val (winnerLabel, scoreLabel, winnerDropdown, scoreRow) = createRefs()
-
-            val winnerName = when (winnerId) {
-                rightUserInfo.userId -> rightUserInfo.name
-                leftUserInfo.userId -> leftUserInfo.name
-                else -> null
-            }
+            AccentAsteriskLabel(
+                text = stringResource(submit_winner),
+            )
 
             SmashingWinnerDropdown(
                 selectedItem = winnerName,
                 items = dropDownList,
                 onClick = onWinnerSelected,
-                enabled = isTextFieldsEnabled,
-                modifier = Modifier.constrainAs(winnerDropdown) {
-                    end.linkTo(parent.end)
-                    top.linkTo(parent.top)
-                    width = Dimension.wrapContent
-                }
-            )
-
-            AccentAsteriskLabel(
-                text = stringResource(submit_winner),
-                modifier = Modifier.constrainAs(winnerLabel) {
-                    start.linkTo(parent.start)
-                    top.linkTo(winnerDropdown.top)
-                    bottom.linkTo(winnerDropdown.bottom)
-                    width = Dimension.wrapContent
-                }
-            )
-
-            Row(
-                modifier = Modifier
-                    .constrainAs(scoreRow) {
-                        end.linkTo(winnerDropdown.end)
-                        start.linkTo(winnerDropdown.start)
-                        top.linkTo(winnerDropdown.bottom, 20.dp)
-                        width = Dimension.fillToConstraints
-                    },
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                ScoreInputTextField(
-                    state = leftTextFieldState,
-                    placeholder = stringResource(zero_label),
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(bottom = 10.dp),
-                    onDoneClick = {
-                        onLeftDoneClick(leftTextFieldState.intValue)
-                    },
-                    isEnabled = isTextFieldsEnabled,
-                )
-
-                Text(
-                    text = stringResource(score_separator),
-                    color = SmashingTheme.colors.txtTertiary,
-                    style = SmashingTheme.typography.md.medium16,
-                    modifier = Modifier.padding(horizontal = 12.dp),
-                )
-
-                ScoreInputTextField(
-                    state = rightTextFieldState,
-                    placeholder = stringResource(zero_label),
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(bottom = 10.dp),
-                    onDoneClick = {
-                        onRightDoneClick(rightTextFieldState.intValue)
-                    },
-                    isEnabled = isTextFieldsEnabled,
-                )
-            }
-
-            AccentAsteriskLabel(
-                text = stringResource(submit_score),
-                modifier = Modifier.constrainAs(scoreLabel) {
-                    top.linkTo(scoreRow.top)
-                    bottom.linkTo(scoreRow.bottom)
-                    width = Dimension.wrapContent
-                }
+                enabled = isContentEnabled,
             )
         }
     }
@@ -192,14 +121,11 @@ private fun AccentAsteriskLabel(
 private fun WriteResultPreview() {
     SmashingAndroidTheme {
         WriteResultContent(
-            rightUserInfo = PlayerInfo(userId = "1", name = "Submitter", score = 4),
-            leftUserInfo = PlayerInfo(userId = "2", name = "Receiver", score = 5),
+            modifier = Modifier.background(color = Color.Black),
+            rightUserInfo = PlayerInfo(userId = "1", name = "Submitter"),
+            leftUserInfo = PlayerInfo(userId = "2", name = "Receiver"),
             winnerId = "1",
-            leftTextFieldState = TextFieldState(),
-            rightTextFieldState = TextFieldState(),
             onWinnerSelected = {},
-            onLeftDoneClick = {},
-            onRightDoneClick = {},
         )
     }
 }

--- a/app/src/main/java/com/smashing/app/presentation/write/component/WriteResultContent.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/component/WriteResultContent.kt
@@ -66,7 +66,7 @@ fun WriteResultContent(
             )
         }
 
-        SubmitScoreCard(
+        SubmitCard(
             leftUser = leftUserInfo,
             rightUser = rightUserInfo,
             winnerId = winnerId,

--- a/app/src/main/java/com/smashing/app/presentation/write/confirm/ConfirmContract.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/confirm/ConfirmContract.kt
@@ -1,9 +1,9 @@
 package com.smashing.app.presentation.write.confirm
 
 import androidx.compose.runtime.Immutable
+import com.smashing.app.data.type.ConfirmDenyType
 import com.smashing.app.data.type.ReviewRatingType
 import com.smashing.app.data.type.ReviewTagType
-import com.smashing.app.data.type.ConfirmDenyType
 import com.smashing.app.presentation.write.model.PlayerInfo
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
@@ -13,8 +13,8 @@ import kotlinx.collections.immutable.persistentSetOf
 interface ConfirmContract {
     @Immutable
     data class State(
-        val submitter: PlayerInfo = PlayerInfo("", "", 0),
-        val receiver: PlayerInfo = PlayerInfo("", "", 0),
+        val submitter: PlayerInfo = PlayerInfo("", ""),
+        val receiver: PlayerInfo = PlayerInfo("", ""),
         val winnerId: String? = null,
         val isButtonEnabled: Boolean = false,
         val selectedRating: ReviewRatingType? = null,

--- a/app/src/main/java/com/smashing/app/presentation/write/confirm/ConfirmResultScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/confirm/ConfirmResultScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -33,9 +31,9 @@ import com.smashing.app.core.designsystem.component.bottomsheet.SmashingBottomSh
 import com.smashing.app.core.designsystem.component.button.SmashingButton
 import com.smashing.app.core.designsystem.component.dialog.SmashingDialog
 import com.smashing.app.core.designsystem.component.topbar.SmashingDefaultTopBar
+import com.smashing.app.core.designsystem.state.TopBarState
 import com.smashing.app.core.designsystem.style.ButtonStyle
 import com.smashing.app.core.designsystem.style.DialogStyle
-import com.smashing.app.core.designsystem.state.TopBarState
 import com.smashing.app.core.designsystem.theme.SmashingAndroidTheme
 import com.smashing.app.core.designsystem.theme.SmashingTheme
 import com.smashing.app.data.type.ConfirmDenyType
@@ -66,8 +64,6 @@ fun ConfirmResultRoute(
 
     ConfirmResultScreen(
         uiState = uiState,
-        leftTextFieldState = viewModel.leftTextFieldState,
-        rightTextFieldState = viewModel.rightTextFieldState,
         onBackClick = navigateUp,
         onConfirmClick = navigateToConfirmReview,
         onDenyClick = if (viewModel.isFirstAttempt) viewModel::showDenyBottomSheet else viewModel::showRejectDialog,
@@ -83,8 +79,6 @@ fun ConfirmResultRoute(
 @Composable
 private fun ConfirmResultScreen(
     uiState: ConfirmContract.State,
-    leftTextFieldState: TextFieldState,
-    rightTextFieldState: TextFieldState,
     onBackClick: () -> Unit,
     onConfirmClick: () -> Unit,
     onDenyClick: () -> Unit,
@@ -121,9 +115,7 @@ private fun ConfirmResultScreen(
                 leftUserInfo = uiState.receiver,
                 rightUserInfo = uiState.submitter,
                 winnerId = uiState.winnerId,
-                leftTextFieldState = rightTextFieldState,
-                rightTextFieldState = leftTextFieldState,
-                isTextFieldsEnabled = false,
+                isContentEnabled = false,
                 title = "경기 결과를 확인해주세요",
             )
 
@@ -198,8 +190,6 @@ private fun ConfirmResultScreenPreview() {
     SmashingAndroidTheme {
         ConfirmResultScreen(
             uiState = ConfirmContract.State(),
-            leftTextFieldState = rememberTextFieldState(3.toString()),
-            rightTextFieldState = rememberTextFieldState(1.toString()),
             onBackClick = {},
             onConfirmClick = {},
             onDenyClick = {},

--- a/app/src/main/java/com/smashing/app/presentation/write/confirm/ConfirmViewModel.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/confirm/ConfirmViewModel.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -172,7 +171,7 @@ class ConfirmViewModel @Inject constructor(
 
     fun rejectSubmission() = viewModelScope.launch {
         val reason = _uiState.value.selectedDenyReason
-        Timber.tag("ooo").d("$reason")
+
         _uiState.update {
             it.copy(
                 confirmUiState = ConfirmUiState.Loading,

--- a/app/src/main/java/com/smashing/app/presentation/write/confirm/ConfirmViewModel.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/confirm/ConfirmViewModel.kt
@@ -45,8 +45,6 @@ class ConfirmViewModel @Inject constructor(
     val sideEffect = _sideEffect.asSharedFlow()
 
     val reviewTextFieldState: TextFieldState = TextFieldState()
-    val leftTextFieldState: TextFieldState = TextFieldState()
-    val rightTextFieldState: TextFieldState = TextFieldState()
 
     init {
         fetchGameSubmission()
@@ -60,14 +58,6 @@ class ConfirmViewModel @Inject constructor(
             submissionId = submissionId,
         ).onSuccess { submissionDetail ->
             updateGameSubmission(submissionDetail)
-
-            val currentState = _uiState.value
-            leftTextFieldState.edit {
-                replace(0, length, currentState.submitter.score.toString())
-            }
-            rightTextFieldState.edit {
-                replace(0, length, currentState.receiver.score.toString())
-            }
         }.onFailure { throwable ->
             updateConfirmUiState(
                 uiState = ConfirmUiState.Failure(
@@ -85,13 +75,11 @@ class ConfirmViewModel @Inject constructor(
             val submitter = PlayerInfo(
                 userId = submissionDetail.submitter.userId,
                 name = submissionDetail.submitter.nickname,
-                score = if (isSubmitterWinner) submissionDetail.winner.score else submissionDetail.loser.score,
             )
 
             val receiver = PlayerInfo(
                 userId = if (isSubmitterWinner) submissionDetail.loser.userId else submissionDetail.winner.userId,
                 name = if (isSubmitterWinner) submissionDetail.loser.nickname else submissionDetail.winner.nickname,
-                score = if (isSubmitterWinner) submissionDetail.loser.score else submissionDetail.winner.score,
             )
 
             currentState.copy(

--- a/app/src/main/java/com/smashing/app/presentation/write/model/PlayerInfo.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/model/PlayerInfo.kt
@@ -3,5 +3,4 @@ package com.smashing.app.presentation.write.model
 data class PlayerInfo(
     val userId: String,
     val name: String,
-    val score: Int,
 )

--- a/app/src/main/java/com/smashing/app/presentation/write/submit/SubmitContract.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/submit/SubmitContract.kt
@@ -10,8 +10,8 @@ import kotlinx.collections.immutable.persistentSetOf
 interface SubmitContract {
     @Immutable
     data class State(
-        val submitter: PlayerInfo = PlayerInfo("", "", 0),
-        val receiver: PlayerInfo = PlayerInfo("", "", 0),
+        val submitter: PlayerInfo = PlayerInfo("", ""),
+        val receiver: PlayerInfo = PlayerInfo("", ""),
         val winnerId: String? = null,
         val isButtonEnabled: Boolean = false,
         val selectedRating: ReviewRatingType? = null,

--- a/app/src/main/java/com/smashing/app/presentation/write/submit/SubmitResultScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/submit/SubmitResultScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -28,9 +27,9 @@ import com.smashing.app.R.string.submit_matching_result
 import com.smashing.app.core.designsystem.component.button.SmashingButton
 import com.smashing.app.core.designsystem.component.dialog.SmashingDialog
 import com.smashing.app.core.designsystem.component.topbar.SmashingDefaultTopBar
+import com.smashing.app.core.designsystem.state.TopBarState
 import com.smashing.app.core.designsystem.style.ButtonStyle
 import com.smashing.app.core.designsystem.style.DialogStyle
-import com.smashing.app.core.designsystem.state.TopBarState
 import com.smashing.app.core.designsystem.theme.SmashingTheme
 import com.smashing.app.core.extension.clearFocus
 import com.smashing.app.presentation.write.component.WriteResultContent
@@ -59,26 +58,18 @@ fun SubmitResultRoute(
         uiState = uiState,
         modifier = modifier,
         onBackClick = navigateUp,
-        onLeftDoneClick = viewModel::updateSubmitterScore,
-        onRightDoneClick = viewModel::updateReceiverScore,
         onWinnerSelected = viewModel::updateSelectedWinner,
         onNextClick = if (viewModel.isFirstAttempt) navigateToSubmitReview else viewModel::showResubmitDialog,
         onConfirmResubmit = viewModel::submitGame,
         onDismissResubmit = viewModel::hideResubmitDialog,
-        leftTextFieldState = viewModel.leftTextFieldState,
-        rightTextFieldState = viewModel.rightTextFieldState,
     )
 }
 
 @Composable
 private fun SubmitResultScreen(
     uiState: SubmitContract.State,
-    leftTextFieldState: TextFieldState,
-    rightTextFieldState: TextFieldState,
     onBackClick: () -> Unit,
     onWinnerSelected: (String) -> Unit,
-    onLeftDoneClick: (Int) -> Unit,
-    onRightDoneClick: (Int) -> Unit,
     onNextClick: () -> Unit,
     onConfirmResubmit: () -> Unit,
     onDismissResubmit: () -> Unit,
@@ -112,11 +103,7 @@ private fun SubmitResultScreen(
                 leftUserInfo = uiState.submitter,
                 rightUserInfo = uiState.receiver,
                 winnerId = uiState.winnerId,
-                leftTextFieldState = leftTextFieldState,
-                rightTextFieldState = rightTextFieldState,
                 onWinnerSelected = onWinnerSelected,
-                onLeftDoneClick = onLeftDoneClick,
-                onRightDoneClick = onRightDoneClick,
                 subTitle = "악의적인 결과 작성 시 활동이 제한될 수 있어요",
             )
 
@@ -153,11 +140,7 @@ private fun SubmitResultScreen(
 private fun SubmitScreenPreview() {
     SubmitResultScreen(
         uiState = SubmitContract.State(),
-        leftTextFieldState = TextFieldState(),
-        rightTextFieldState = TextFieldState(),
         onBackClick = {},
-        onLeftDoneClick = {},
-        onRightDoneClick = {},
         onWinnerSelected = {},
         onNextClick = {},
         onConfirmResubmit = {},

--- a/app/src/main/java/com/smashing/app/presentation/write/submit/SubmitViewModel.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/submit/SubmitViewModel.kt
@@ -62,9 +62,7 @@ class SubmitViewModel @Inject constructor(
         }.onFailure { throwable ->
             _uiState.update {
                 it.copy(
-                    submitUiState = SubmitContract.SubmitUiState.Failure(
-                        throwable.message ?: "이전 제출 결과 조회 실패"
-                    )
+                    submitUiState = SubmitContract.SubmitUiState.Failure("이전 제출 결과 조회 실패")
                 )
             }
         }
@@ -195,9 +193,7 @@ class SubmitViewModel @Inject constructor(
         }.onFailure { throwable ->
             _uiState.update {
                 it.copy(
-                    submitUiState = SubmitContract.SubmitUiState.Failure(
-                        throwable.message ?: "경기 결과 제출 실패"
-                    ),
+                    submitUiState = SubmitContract.SubmitUiState.Failure("경기 결과 제출 실패"),
                     isResubmitDialogVisible = false,
                     isAlertDialogOpen = false,
                     isConfirmDialogOpen = true,

--- a/app/src/main/java/com/smashing/app/presentation/write/submit/SubmitViewModel.kt
+++ b/app/src/main/java/com/smashing/app/presentation/write/submit/SubmitViewModel.kt
@@ -40,6 +40,9 @@ class SubmitViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(SubmitContract.State())
     val uiState = _uiState.asStateFlow()
 
+    private val _sideEffect = MutableSharedFlow<SideEffect>()
+    val sideEffect = _sideEffect.asSharedFlow()
+
     init {
         if (!isFirstAttempt) {
             fetchPreviousSubmission()
@@ -74,13 +77,11 @@ class SubmitViewModel @Inject constructor(
         val submitter = PlayerInfo(
             userId = submissionDetail.submitter.userId,
             name = submissionDetail.submitter.nickname,
-            score = if (isSubmitterWinner) submissionDetail.winner.score else submissionDetail.loser.score,
         )
 
         val receiver = PlayerInfo(
             userId = if (isSubmitterWinner) submissionDetail.loser.userId else submissionDetail.winner.userId,
             name = if (isSubmitterWinner) submissionDetail.loser.nickname else submissionDetail.winner.nickname,
-            score = if (isSubmitterWinner) submissionDetail.loser.score else submissionDetail.winner.score,
         )
 
         _uiState.update { state ->
@@ -88,20 +89,8 @@ class SubmitViewModel @Inject constructor(
                 submitter = submitter,
                 receiver = receiver,
                 winnerId = submissionDetail.winner.userId,
-                isButtonEnabled = isScoreMatchingWinner(
-                    isSubmitterWinner = isSubmitterWinner,
-                    submitterScore = submitter.score,
-                    receiverScore = receiver.score,
-                ),
+                isButtonEnabled = true,
             )
-        }
-
-        val currentState = _uiState.value
-        leftTextFieldState.edit {
-            replace(0, length, currentState.submitter.score.toString())
-        }
-        rightTextFieldState.edit {
-            replace(0, length, currentState.receiver.score.toString())
         }
     }
 
@@ -114,76 +103,26 @@ class SubmitViewModel @Inject constructor(
                 submitter = PlayerInfo(
                     userId = currentUserId,
                     name = currentUserNickname,
-                    score = 0
                 ),
-                receiver = PlayerInfo(userId = opponentUserId, name = opponentNickname, score = 0),
+                receiver = PlayerInfo(
+                    userId = opponentUserId,
+                    name = opponentNickname,
+                ),
             )
         }
     }
 
-    private val _sideEffect = MutableSharedFlow<SideEffect>()
-    val sideEffect = _sideEffect.asSharedFlow()
-
-    val leftTextFieldState: TextFieldState = TextFieldState()
-    val rightTextFieldState: TextFieldState = TextFieldState()
     val reviewTextFieldState: TextFieldState = TextFieldState()
 
     fun updateSelectedWinner(winnerName: String) = _uiState.update { state ->
         val winnerId =
             if (winnerName == state.submitter.name) state.submitter.userId else state.receiver.userId
-        val isSubmitterWinner = winnerId == state.submitter.userId
+
         state.copy(
             winnerId = winnerId,
-            isButtonEnabled = hasBothScoreInputs() &&
-                    isScoreMatchingWinner(
-                        isSubmitterWinner = isSubmitterWinner,
-                        submitterScore = state.submitter.score,
-                        receiverScore = state.receiver.score,
-                    ),
+            isButtonEnabled = true,
         )
     }
-
-    fun updateSubmitterScore(score: Int) = _uiState.update { state ->
-        val updatedSubmitter = state.submitter.copy(score = score)
-        val isSubmitterWinner = state.winnerId == updatedSubmitter.userId
-
-        state.copy(
-            submitter = updatedSubmitter,
-            isButtonEnabled = state.winnerId != null &&
-                    hasBothScoreInputs() &&
-                    isScoreMatchingWinner(
-                        isSubmitterWinner = isSubmitterWinner,
-                        submitterScore = score,
-                        receiverScore = state.receiver.score,
-                    ),
-        )
-    }
-
-    fun updateReceiverScore(score: Int) = _uiState.update { state ->
-        val updatedReceiver = state.receiver.copy(score = score)
-        val isSubmitterWinner = state.winnerId == state.submitter.userId
-
-        state.copy(
-            receiver = updatedReceiver,
-            isButtonEnabled = state.winnerId != null &&
-                    hasBothScoreInputs() &&
-                    isScoreMatchingWinner(
-                        isSubmitterWinner = isSubmitterWinner,
-                        submitterScore = state.submitter.score,
-                        receiverScore = score,
-                    ),
-        )
-    }
-
-    private fun isScoreMatchingWinner(
-        isSubmitterWinner: Boolean,
-        submitterScore: Int,
-        receiverScore: Int,
-    ): Boolean = if (isSubmitterWinner) submitterScore > receiverScore
-    else receiverScore > submitterScore
-
-    private fun hasBothScoreInputs(): Boolean =
-        leftTextFieldState.text.isNotBlank() && rightTextFieldState.text.isNotBlank()
 
     fun updateSelectedRatingType(type: ReviewRatingType) = _uiState.update { state ->
         state.copy(
@@ -217,15 +156,11 @@ class SubmitViewModel @Inject constructor(
 
     fun submitGame() = viewModelScope.launch {
         val state = _uiState.value
-        val winnerId = state.winnerId
-
-        if (winnerId == null) return@launch
+        val winnerId = state.winnerId ?: return@launch
 
         _uiState.update { it.copy(submitUiState = SubmitContract.SubmitUiState.Loading) }
 
         val isSubmitterWinner = winnerId == state.submitter.userId
-        val (winnerScore, loserScore) = if (isSubmitterWinner) state.submitter.score to state.receiver.score
-        else state.receiver.score to state.submitter.score
 
         val loserId = if (isSubmitterWinner) state.receiver.userId else state.submitter.userId
 
@@ -241,8 +176,6 @@ class SubmitViewModel @Inject constructor(
         val gameSubmission = GameSubmission(
             winnerUserId = winnerId,
             loserUserId = loserId,
-            winnerScore = winnerScore,
-            loserScore = loserScore,
             review = review,
         )
 
@@ -262,7 +195,9 @@ class SubmitViewModel @Inject constructor(
         }.onFailure { throwable ->
             _uiState.update {
                 it.copy(
-                    submitUiState = SubmitContract.SubmitUiState.Failure("경기 결과 제출 실패"),
+                    submitUiState = SubmitContract.SubmitUiState.Failure(
+                        throwable.message ?: "경기 결과 제출 실패"
+                    ),
                     isResubmitDialogVisible = false,
                     isAlertDialogOpen = false,
                     isConfirmDialogOpen = true,


### PR DESCRIPTION
## Related issue 🛠
- closed #265

## Work Description ✏️
- 결과 작성, 확인하기 점수 입력 필드 제거
- 관련 로직 제거
- 관련 모델 제거

## Screenshot 📸
| 결과 작성하기 | 결과 확인하기|
|:------------:|:-----------:|
| <img width="360" alt="image" src="https://github.com/user-attachments/assets/e97b535b-caa4-4b13-92d0-4a66b9699262" />  | <img width="360" alt="image" src="https://github.com/user-attachments/assets/937a7f79-31d1-4ea8-9f8a-7c30404a9a50" /> |

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
아직 서버쪽 반영은 안해둔 상태여서 남은 작업은 새로 이슈 파서 작업해두겠습니다 !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**리팩토링**
- 게임 제출 프로세스에서 점수 입력 기능이 제거되었습니다.
- 결과 제출 화면이 간소화되어 승자 선택에만 집중할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->