### PR TITLE
[FIX/#309] 2차 QA 매칭, 알림 뷰 문구 수정

### DIFF
--- a/app/src/main/java/com/smashing/app/data/repository/api/UserRepository.kt
+++ b/app/src/main/java/com/smashing/app/data/repository/api/UserRepository.kt
@@ -1,13 +1,11 @@
 package com.smashing.app.data.repository.api
 
-import com.smashing.app.data.model.review.GameReviewResult
 import com.smashing.app.data.model.profile.user.UserProfileInfo
+import com.smashing.app.data.model.review.GameReviewResult
 
 interface UserRepository {
     suspend fun getUserProfileId(): String?
     suspend fun getUserNickname(): String?
-    suspend fun setUserInfo(userProfileId: String, userNickname: String)
-    suspend fun clearUserInfo()
     suspend fun getUserInfoDetail(
         userProfileId: String,
         sportCode: String?,

--- a/app/src/main/java/com/smashing/app/data/repository/impl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/smashing/app/data/repository/impl/UserRepositoryImpl.kt
@@ -21,12 +21,6 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun getUserNickname(): String? =
         localUserDataSource.getUserNickName()
 
-    override suspend fun setUserInfo(userProfileId: String, userNickname: String) =
-        localUserDataSource.setUserInfo(userProfileId, userNickname)
-
-    override suspend fun clearUserInfo() =
-        localUserDataSource.clearUserInfo()
-
     override suspend fun getUserInfoDetail(
         userProfileId: String,
         sportCode: String?

--- a/app/src/main/java/com/smashing/app/data/type/SportType.kt
+++ b/app/src/main/java/com/smashing/app/data/type/SportType.kt
@@ -22,7 +22,6 @@ enum class SportType(
     );
 
     companion object {
-        fun findSportType(sportId: Long): SportType = entries.find { it.id == sportId } ?: PING_PONG
         fun findSportTypeToSportName(sportName: String): SportType = entries.find { it.sportName == sportName } ?: PING_PONG
         fun findSportTypeToSportCode(sportCode: String): SportType = entries.find { it.code == sportCode } ?: PING_PONG
     }

--- a/app/src/main/java/com/smashing/app/presentation/confirmreview/ConfirmReviewScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/confirmreview/ConfirmReviewScreen.kt
@@ -20,13 +20,13 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.smashing.app.R.drawable.ic_thumbs_down_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_double_lg
 import com.smashing.app.R.drawable.ic_thumbs_up_lg
-import com.smashing.app.R.string.review
 import com.smashing.app.R.string.confirm
 import com.smashing.app.R.string.confirm_review_arrived_with_nickname
+import com.smashing.app.R.string.review
 import com.smashing.app.core.designsystem.component.button.SmashingButton
 import com.smashing.app.core.designsystem.component.topbar.SmashingDefaultTopBar
-import com.smashing.app.core.designsystem.style.ButtonStyle
 import com.smashing.app.core.designsystem.state.TopBarState
+import com.smashing.app.core.designsystem.style.ButtonStyle
 import com.smashing.app.core.designsystem.theme.SmashingAndroidTheme
 import com.smashing.app.core.designsystem.theme.SmashingTheme
 import com.smashing.app.data.type.ReviewRatingType
@@ -43,7 +43,6 @@ fun ConfirmReviewRoute(
 
     ConfirmReviewScreen(
         uiState = uiState,
-        onBackClick = navigateUp,
         onConfirmClick = navigateUp,
         modifier = modifier,
     )
@@ -52,7 +51,6 @@ fun ConfirmReviewRoute(
 @Composable
 private fun ConfirmReviewScreen(
     uiState: ConfirmReviewContract.State,
-    onBackClick: () -> Unit,
     onConfirmClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -126,7 +124,6 @@ private fun ConfirmReviewScreenPreview() {
                 reviewText = "매너가 좋으셨습니다. 다음에 또 해요!",
                 tags = persistentListOf("시간 약속을 잘 지켜요", "경기 매너가 좋아요"),
             ),
-            onBackClick = {},
             onConfirmClick = {},
         )
     }

--- a/app/src/main/java/com/smashing/app/presentation/notice/NoticeScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/notice/NoticeScreen.kt
@@ -21,6 +21,10 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.smashing.app.R
+import com.smashing.app.R.string.no
+import com.smashing.app.R.string.notice_change_dialog_change_btn
+import com.smashing.app.R.string.notice_change_dialog_subtitle
+import com.smashing.app.R.string.notice_change_dialog_title
 import com.smashing.app.core.designsystem.component.appicon.AppIcon
 import com.smashing.app.core.designsystem.component.dialog.SmashingDialog
 import com.smashing.app.core.designsystem.component.topbar.SmashingDefaultTopBar
@@ -30,8 +34,10 @@ import com.smashing.app.core.designsystem.theme.SmashingAndroidTheme
 import com.smashing.app.core.designsystem.theme.SmashingTheme
 import com.smashing.app.core.extension.onBottomReached
 import com.smashing.app.data.model.notification.Notification
+import com.smashing.app.data.type.SportType
 import com.smashing.app.presentation.matching.type.MatchingType
 import com.smashing.app.presentation.notice.component.NoticeItem
+
 
 @Composable
 fun NoticeRoute(
@@ -136,14 +142,16 @@ private fun NoticeScreen(
             )
 
             if (uiState.isChangeDialogVisible) {
-                val sportName = uiState.targetChangeSport.sportType.sportName
+                val sport = uiState.targetChangeSport.sportType
+                val sportText = sport.sportName + if (sport == SportType.BADMINTON) "으로" else "로"
+
                 SmashingDialog(
-                    title = "${sportName}로 종목을 변경하시겠어요?",
+                    title = stringResource(notice_change_dialog_title, sportText),
                     onDismissClick = onDismissChangeProfile,
-                    subtitle = "종목은 재변경 가능합니다.",
+                    subtitle = stringResource(notice_change_dialog_subtitle),
                     type = DialogStyle.ALERT,
-                    confirmText = "변경하기",
-                    dismissText = "아니요",
+                    confirmText = stringResource(notice_change_dialog_change_btn),
+                    dismissText = stringResource(no),
                     onConfirmClick = onConfirmChangeProfile,
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+
     <!--Common  -->
     <string name="home">홈</string>
     <string name="matching_search">매칭 탐색</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -362,14 +362,14 @@
     <string name="matching_btn_canceled">매칭 취소 대기 중</string>
     <string name="matching_btn_unknown">unknown</string>
     <string name="matching_receive">받은 매칭</string>
-    <string name="matching_receive_empty">받은 요청이 없어요</string>
+    <string name="matching_receive_empty">받은 매칭이 없어요</string>
     <string name="matching_send">보낸 매칭</string>
-    <string name="matching_send_empty">보낸 요청이 없어요</string>
+    <string name="matching_send_empty">보낸 매칭이 없어요</string>
     <string name="matching_confirm">매칭 확정</string>
     <string name="matching_confirm_empty">확정된 매칭이 없어요</string>
     <string name="matching_empty_description">직접 경쟁을 신청해보세요!</string>
     <string name="matching_send_dialog_title">요청을 취소하시겠습니까?</string>
-    <string name="matching_send_dialog_description">요청 취소 시 24시간 후 재요청할 수 있습니다.</string>
+    <string name="matching_send_dialog_description">취소 시 24시간 후 재요청할 수 있습니다.</string>
     <string name="matching_accepted_dialog_title">정말 매칭을 취소하시겠습니까?</string>
     <string name="matching_accepted_dialog_description">매칭 상대도 동의해야 취소가 완료됩니다.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,6 +385,9 @@
 
     <!--Notice  -->
     <string name="notice">알림</string>
+    <string name="notice_change_dialog_title">%s 종목을 변경하시겠어요?</string>
+    <string name="notice_change_dialog_subtitle">종목은 내 프로필에서 재변경 가능합니다.</string>
+    <string name="notice_change_dialog_change_btn">변경하기</string>
 
     <!--Profile-->
     <string name="profile_add_sports_label">+</string>
@@ -444,7 +447,6 @@
     <string name="mypage_info_version">버전 정보</string>
     <string name="mypage_my_profile">내 프로필</string>
     <string name="mypage_logout_message">정말 로그아웃하시겠습니까?</string>
-
 
 
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #309

## Work Description ✏️
- 불필요한 코드 제거
- 매칭 관리탭 "요청" -> "매칭" 문구 수정
- 알림화면 종목 변경 문구 수정

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
- [ ] SSE 이벤트 미반영된 부분 처리

## To Reviewers 📢
QA 사항 중 문구가 일부 다른 부분을 수정했습니다.
SSE 쪽은 아직 처리될 부분이 남아서 서버 쪽에서 수정해주시면 새로 이슈 파서 작업할게요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 종목 변경 확인 대화상자에 지역화된 문자열 추가

* **개선 사항**
  * 매칭 관련 화면의 용어 일관성 개선 ("요청"에서 "매칭"으로 변경)
  * 알림 화면의 문자열을 리소스 기반으로 지역화

* **리팩토링**
  * 미사용 메서드 및 함수 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->