### PR TITLE
[FIX/#311] 매칭 신청 후 데이터 재호출 수정

### DIFF
--- a/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileContract.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileContract.kt
@@ -19,7 +19,6 @@ class UserProfileContract {
         val gameReview: ImmutableList<GameReview> = persistentListOf(),
         val gameReviewResult: GameReviewResult = GameReviewResult(),
         val userProfileId: String = "",
-        val isMatchingPossible: Boolean = true,
         val userProfileCursor: Cursor = Cursor(),
         val isDialogVisible: Boolean = false,
         val isUserNotFound: Boolean = false,

--- a/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileContract.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileContract.kt
@@ -19,7 +19,7 @@ class UserProfileContract {
         val gameReview: ImmutableList<GameReview> = persistentListOf(),
         val gameReviewResult: GameReviewResult = GameReviewResult(),
         val userProfileId: String = "",
-        val isMatchingRequest: Boolean = true,
+        val isMatchingPossible: Boolean = true,
         val userProfileCursor: Cursor = Cursor(),
         val isDialogVisible: Boolean = false,
         val isUserNotFound: Boolean = false,

--- a/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileScreen.kt
@@ -171,7 +171,7 @@ private fun UserProfileScreen(
                     loseCount = uiState.activeProfile.loseCount,
                     reviewCount = uiState.userProfileInfo.reviewCount,
                     onCompeteClick = onCompeteClick,
-                    isCompeteEnabled = uiState.isChallengeable,
+                    isCompeteEnabled = uiState.isChallengeable && uiState.isMatchingPossible,
                 )
 
                 if (uiState.isDialogVisible) {

--- a/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileScreen.kt
@@ -172,7 +172,6 @@ private fun UserProfileScreen(
                     reviewCount = uiState.userProfileInfo.reviewCount,
                     onCompeteClick = onCompeteClick,
                     isCompeteEnabled = uiState.isChallengeable,
-                    //isCompeteEnabled = uiState.isChallengeable && uiState.isMatchingPossible,
                 )
 
                 if (uiState.isDialogVisible) {

--- a/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileScreen.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileScreen.kt
@@ -171,7 +171,8 @@ private fun UserProfileScreen(
                     loseCount = uiState.activeProfile.loseCount,
                     reviewCount = uiState.userProfileInfo.reviewCount,
                     onCompeteClick = onCompeteClick,
-                    isCompeteEnabled = uiState.isChallengeable && uiState.isMatchingPossible,
+                    isCompeteEnabled = uiState.isChallengeable,
+                    //isCompeteEnabled = uiState.isChallengeable && uiState.isMatchingPossible,
                 )
 
                 if (uiState.isDialogVisible) {

--- a/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileViewModel.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileViewModel.kt
@@ -219,7 +219,6 @@ class UserProfileViewModel @Inject constructor(
                 _uiState.update { currentState ->
                     currentState.copy(
                         loadState = UserProfileUiState.Success,
-                        //isMatchingPossible = false
                     )
                 }
                 fetchProfileInfo()

--- a/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileViewModel.kt
+++ b/app/src/main/java/com/smashing/app/presentation/profile/userprofile/UserProfileViewModel.kt
@@ -219,8 +219,10 @@ class UserProfileViewModel @Inject constructor(
                 _uiState.update { currentState ->
                     currentState.copy(
                         loadState = UserProfileUiState.Success,
+                        //isMatchingPossible = false
                     )
                 }
+                fetchProfileInfo()
             }.onFailure { exception ->
                 _uiState.update {
                     it.copy(


### PR DESCRIPTION
## Related issue 🛠
- closed #311

## Work Description ✏️
- 매칭 신청 후 데이터를 재호출합니다.

## Screenshot 📸
https://github.com/user-attachments/assets/e9619d67-2cd4-46a6-9007-2a8ff105442e



## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 세상에 버튼 활성화 여부 처리 안해줘도 되는거였군요 신경쓰지 마십시오 다들 맛저하세용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 다른 사용자와의 경쟁을 신청한 후 프로필 정보가 자동으로 업데이트되어 항상 최신 상태를 유지하도록 개선했습니다.

* **리팩토링**
  * 사용자 프로필 상태 관리 관련 내부 코드를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->